### PR TITLE
Atomic fhirpath lsp

### DIFF
--- a/packages/aidbox-fhirpath-lsp/.gitignore
+++ b/packages/aidbox-fhirpath-lsp/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/dist
+
+*storybook.log
+storybook-static

--- a/packages/aidbox-fhirpath-lsp/.swcrc
+++ b/packages/aidbox-fhirpath-lsp/.swcrc
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://swc.rs/schema.json",
+  "module": {
+    "type": "es6",
+    "strict": true,
+    "strictMode": true,
+    "lazy": false,
+    "noInterop": true,
+    "resolveFully": true
+  },
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": false,
+      "decorators": false,
+      "dynamicImport": false
+    },
+    "transform": {
+      "legacyDecorator": false,
+      "decoratorMetadata": false,
+      "react": {
+        "runtime": "automatic",
+        "development": false,
+        "useBuiltins": false
+      }
+    },
+    "target": "esnext",
+    "loose": false,
+    "externalHelpers": false,
+    "keepClassNames": false,
+    "baseUrl": "."
+  },
+  "isModule": true,
+  "sourceMaps": true
+}

--- a/packages/aidbox-fhirpath-lsp/biome.json
+++ b/packages/aidbox-fhirpath-lsp/biome.json
@@ -1,0 +1,53 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"includes": [
+			".storybook/**",
+			"src/**",
+			"example/**",
+			".vscode/**",
+			"biome.json",
+			"index.html",
+			"package.json",
+			"tsconfig.app.json",
+			"tsconfig.json",
+			"tsconfig.node.json",
+			"vite.config.ts",
+			"scripts/**"
+		],
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"domains": {
+			"project": "recommended",
+			"react": "recommended",
+			"test": "recommended"
+		},
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/packages/aidbox-fhirpath-lsp/example/main.ts
+++ b/packages/aidbox-fhirpath-lsp/example/main.ts
@@ -1,0 +1,118 @@
+import {
+	autocompletion,
+	closeBrackets,
+	closeBracketsKeymap,
+	completionKeymap,
+} from "@codemirror/autocomplete";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+	bracketMatching,
+	defaultHighlightStyle,
+	foldGutter,
+	foldKeymap,
+	indentOnInput,
+	syntaxHighlighting,
+} from "@codemirror/language";
+import { lintKeymap } from "@codemirror/lint";
+import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+import { EditorState } from "@codemirror/state";
+import {
+	crosshairCursor,
+	drawSelection,
+	dropCursor,
+	EditorView,
+	highlightActiveLine,
+	highlightActiveLineGutter,
+	highlightSpecialChars,
+	keymap,
+	lineNumbers,
+	rectangularSelection,
+} from "@codemirror/view";
+import {
+	type AidboxClient,
+	type AuthProvider,
+	BrowserAuthProvider,
+	makeClient,
+} from "@health-samurai/aidbox-client";
+import { createCodeMirrorLsp } from "../src/index";
+
+const initialText = `Patient
+  .name
+  .where( use = 'official' )
+  .first()`;
+
+const aidboxUrl = "http://localhost:8080";
+const authProvider: AuthProvider = new BrowserAuthProvider(aidboxUrl);
+const client: AidboxClient = makeClient({
+	baseUrl: aidboxUrl,
+	authProvider: authProvider,
+});
+const { extension: lspExtension } = createCodeMirrorLsp(client, {
+	debug: true,
+});
+
+const editorState = EditorState.create({
+	doc: initialText,
+	extensions: [
+		lineNumbers(),
+		highlightActiveLineGutter(),
+		highlightSpecialChars(),
+		history(),
+		foldGutter(),
+		drawSelection(),
+		dropCursor(),
+		EditorState.allowMultipleSelections.of(true),
+		indentOnInput(),
+		syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+		bracketMatching(),
+		closeBrackets(),
+		autocompletion(),
+		rectangularSelection(),
+		crosshairCursor(),
+		highlightActiveLine(),
+		highlightSelectionMatches(),
+		keymap.of([
+			...closeBracketsKeymap,
+			...defaultKeymap,
+			...searchKeymap,
+			...historyKeymap,
+			...foldKeymap,
+			...completionKeymap,
+			...lintKeymap,
+		]),
+		// Theme for better visibility
+		EditorView.theme({
+			"&": {
+				fontSize: "14px",
+			},
+			".cm-tooltip.cm-tooltip-autocomplete": {
+				"& > ul": {
+					fontFamily: "monospace",
+					maxHeight: "200px",
+					maxWidth: "400px",
+				},
+			},
+		}),
+		// autocompletion({
+		//   activateOnTyping: true,
+		//   activateOnTypingDelay: 0, // No delay for triggers
+		//   selectOnOpen: true, // Auto-select first item
+		//   closeOnBlur: true, // Close on blur
+		//   maxRenderedOptions: 100, // Max items to render
+		//   defaultKeymap: true, // Use default keybindings
+		//   icons: true, // Add icons for completion types
+		// }),
+		// syntaxHighlighting(defaultHighlightStyle),
+		lspExtension,
+	],
+});
+
+const cmElement = document.getElementById("cm");
+if (cmElement === null) {
+	throw Error("No #cm element");
+}
+
+const _editorView = new EditorView({
+	state: editorState,
+	parent: cmElement,
+});

--- a/packages/aidbox-fhirpath-lsp/index.html
+++ b/packages/aidbox-fhirpath-lsp/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>test1</title>
+</head>
+
+<body>
+    <div id="cm"></div>
+    <div id="log"></div>
+    <script type="module" src="/example/main.ts"></script>
+</body>
+
+</html>

--- a/packages/aidbox-fhirpath-lsp/package.json
+++ b/packages/aidbox-fhirpath-lsp/package.json
@@ -1,0 +1,57 @@
+{
+	"name": "@health-samurai/aidbox-fhirpath-lsp",
+	"version": "0.0.0-alpha.1",
+	"type": "module",
+	"files": [
+		"dist",
+		"src"
+	],
+	"exports": {
+		".": "./dist/src/index.js"
+	},
+	"scripts": {
+		"build": "rm -rf dist && mkdir -p dist && swc src -d dist -D && tsc -b --force && echo success",
+		"build:watch": "tsx scripts/watch.node.ts",
+		"format": "biome format",
+		"format:check": "biome format",
+		"format:fix": "biome format --write",
+		"lint": "biome check",
+		"lint:check": "biome check",
+		"lint:fix": "biome check --write",
+		"tsc:check": "tsc -b --noEmit"
+	},
+	"dependencies": {
+		"@atomic-ehr/fhirpath": "0.0.5",
+		"@atomic-ehr/fhirpath-lsp": "0.0.2",
+		"@health-samurai/aidbox-client": "workspace:*",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0"
+	},
+	"devDependencies": {
+		"@codemirror/autocomplete": "^6.20.0",
+		"@codemirror/commands": "^6.8.1",
+		"@codemirror/language": "^6.11.3",
+		"@codemirror/lint": "^6.8.5",
+		"@codemirror/lsp-client": "^6.2.0",
+		"@codemirror/search": "^6.5.11",
+		"@codemirror/state": "^6.5.2",
+		"@codemirror/theme-one-dark": "^6.1.3",
+		"@codemirror/view": "^6.38.1",
+		"@swc/cli": "^0.7.8",
+		"@swc/core": "^1.13.5",
+		"@types/react": "^19.1.9",
+		"chokidar": "^4.0.3",
+		"tsdown": "^0.16.6",
+		"tsx": "^4.20.4",
+		"typescript": "~5.8.3",
+		"vite": "^7.0.6",
+		"vitest": "^3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/HealthSamurai/aidbox-ts-sdk"
+	}
+}

--- a/packages/aidbox-fhirpath-lsp/src/hooks.ts
+++ b/packages/aidbox-fhirpath-lsp/src/hooks.ts
@@ -1,0 +1,144 @@
+import {
+	LSPClient,
+	languageServerExtensions,
+	type Transport,
+} from "@codemirror/lsp-client";
+import type { Extension } from "@codemirror/state";
+import type { AidboxClient, Bundle } from "@health-samurai/aidbox-client";
+import * as React from "react";
+import { wrapCache } from "./idb-cache";
+import type { Resource } from "./messages";
+import { startServer } from "./wrapper";
+
+type CreateCodeMirrorLspOpts = {
+	debug?: boolean;
+};
+
+type CreateResult = {
+	extension: Extension;
+	worker: Worker;
+};
+
+export function createCodeMirrorLsp(
+	client: AidboxClient,
+	{ debug }: CreateCodeMirrorLspOpts,
+): CreateResult {
+	const defaultLspHandler = (data: string) => {
+		if (debug) {
+			console.log("!!!", data);
+		}
+	};
+
+	let onLspMessageReceive: (value: string) => void = defaultLspHandler;
+
+	const channel = new MessageChannel();
+	const editorPort = channel.port1;
+	const lspPort = channel.port2;
+
+	editorPort.onmessage = (ev) => {
+		onLspMessageReceive(JSON.stringify(ev.data));
+	};
+
+	async function resolve(canonicalUrl: string): Promise<Resource | null> {
+		const response = await client.request<Bundle>({
+			method: "GET",
+			url: "/fhir/StructureDefinition",
+			params: [["url", canonicalUrl]],
+		});
+
+		if (!response.ok) {
+			return null;
+		} else {
+			// There is type conflict between aidbox client and atomic
+			// id of the StructureDefinition is not checked,
+			// so we can safely cast here.
+			return (response.value.resource.entry?.[0]?.resource ??
+				null) as Resource | null;
+		}
+	}
+
+	async function search(
+		kind: "primitive-type" | "complex-type" | "resource",
+	): Promise<Resource[]> {
+		const response = await client.request<Bundle>({
+			method: "GET",
+			url: "/fhir/StructureDefinition",
+			params: [["kind", kind]],
+		});
+
+		if (!response.ok) {
+			return [];
+		} else {
+			return (
+				response.value.resource.entry
+					// There is type conflict between aidbox client and atomic
+					// id of the StructureDefinition is not checked,
+					// so we can safely cast here.
+					?.map((entry) => entry.resource as Resource | undefined)
+					.filter((resource) => resource !== undefined) ?? []
+			);
+		}
+	}
+
+	const lspTransport: Transport = {
+		send(message: string) {
+			if (debug) {
+				console.log(">>>", message);
+			}
+			editorPort.postMessage(JSON.parse(message));
+		},
+		subscribe(handler: (value: string) => void) {
+			onLspMessageReceive = (value: string) => {
+				if (debug) {
+					console.log("<<<", value);
+				}
+				handler(value);
+			};
+		},
+		unsubscribe(_handler: (value: string) => void) {
+			onLspMessageReceive = defaultLspHandler;
+		},
+	};
+	const lspClient = new LSPClient({
+		extensions: languageServerExtensions(),
+	}).connect(lspTransport);
+
+	const worker = startServer(
+		wrapCache({
+			resolve: async (canonicalUrl: string) => {
+				return await resolve(canonicalUrl);
+			},
+			search: async (kind) => {
+				return await search(kind);
+			},
+			port: lspPort,
+		}),
+	);
+
+	return {
+		extension: lspClient.plugin("file:///doc.fhirpath"),
+		worker: worker,
+	};
+}
+
+export function useCodeMirrorLsp(
+	client: AidboxClient,
+	opts: CreateCodeMirrorLspOpts,
+): Extension {
+	const [lspExtension, setLspExtension] = React.useState<Extension>([]);
+	const ref = React.useRef<CreateResult | null>(null);
+
+	const { debug } = opts;
+
+	React.useEffect(() => {
+		const result = createCodeMirrorLsp(client, debug ? { debug: true } : {});
+		ref.current = result;
+		setLspExtension([result.extension]);
+
+		return () => {
+			result.worker.terminate();
+		};
+	}, [client, debug]);
+
+	return lspExtension;
+}

--- a/packages/aidbox-fhirpath-lsp/src/idb-cache.ts
+++ b/packages/aidbox-fhirpath-lsp/src/idb-cache.ts
@@ -1,0 +1,176 @@
+import type { ServerOptions } from "@atomic-ehr/fhirpath-lsp";
+import type { Resource } from "./messages";
+
+export function wrapCache(opts: ServerOptions): ServerOptions {
+	let db: IDBDatabase | undefined;
+	let dbErrorReported = false;
+
+	const canonicalByUrlStore = "canonicalByUrl";
+	const canonicalsByKindStore = "canonicalsByKind";
+
+	const req = self.indexedDB.open("aidbox-fhirpath-lsp-cache", 1);
+	req.onerror = (ev) => {
+		console.error(ev);
+		console.error(
+			"Could not open IndexedDB database. Falling back to direct requests.",
+		);
+		db = undefined;
+	};
+	req.onsuccess = (_ev) => {
+		const resDb = req.result;
+		db = resDb;
+
+		resDb.onversionchange = (_ev) => {
+			console.log("DB version changed. Closing the database.");
+			resDb.close();
+			db = undefined;
+		};
+	};
+	req.onupgradeneeded = (_ev) => {
+		const resDb = req.result;
+		try {
+			resDb.deleteObjectStore(canonicalByUrlStore);
+		} catch {}
+		try {
+			resDb.deleteObjectStore(canonicalsByKindStore);
+		} catch {}
+		resDb.createObjectStore(canonicalByUrlStore, {
+			keyPath: "url",
+		});
+		resDb.createObjectStore(canonicalsByKindStore);
+		db = resDb;
+	};
+	req.onblocked = (ev) => {
+		console.error(ev);
+		console.log("DB is blocked");
+		db = undefined;
+	};
+
+	const reportDbUnavailable = (msg?: string) => {
+		if (dbErrorReported === false) {
+			console.error(msg ?? "Indexed DB unavailable");
+			dbErrorReported = true;
+		}
+	};
+
+	const tryCache = <T>(store: string, key: string): Promise<T | undefined> => {
+		if (db === undefined) {
+			return Promise.resolve(undefined);
+		}
+
+		return new Promise<T | undefined>((resolve, reject) => {
+			if (db === undefined) {
+				reportDbUnavailable();
+				reject("DB closed.");
+				return;
+			}
+
+			const transaction = db.transaction(store, "readonly");
+			const objectStore = transaction.objectStore(store);
+			const request = objectStore.get(key);
+			request.onsuccess = (_ev) => {
+				if (request.result === undefined) {
+					resolve(undefined);
+					return;
+				}
+				resolve(request.result as T);
+			};
+			request.onerror = (ev) => {
+				reject(ev);
+			};
+		});
+	};
+
+	const updateCache = <T>(
+		store: string,
+		value: T,
+		key?: string,
+	): Promise<boolean> => {
+		if (db === undefined) {
+			reportDbUnavailable();
+			return Promise.resolve(false);
+		}
+
+		return new Promise<boolean>((resolve, reject) => {
+			if (db === undefined) {
+				reportDbUnavailable();
+				reject(false);
+				return;
+			}
+
+			const transaction = db.transaction(store, "readwrite");
+			const objectStore = transaction.objectStore(store);
+			const request = objectStore.put(value, key);
+			request.onsuccess = (_ev) => {
+				resolve(true);
+			};
+			request.onerror = (ev) => {
+				console.error(ev);
+				console.error("Could not update cached value");
+				reject(false);
+			};
+		});
+	};
+
+	const resolve = async (canonicalUrl: string): Promise<Resource | null> => {
+		let value: Resource | undefined;
+		try {
+			value = await tryCache<Resource>(canonicalByUrlStore, canonicalUrl);
+		} catch (e) {
+			console.error(e);
+			console.error("Error checking for cached canonical by URL");
+			value = undefined;
+		}
+
+		if (value !== undefined) {
+			return value;
+		}
+
+		const newValue = await opts.resolve(canonicalUrl);
+
+		if (newValue === null) {
+			return newValue;
+		}
+
+		value = newValue;
+
+		try {
+			await updateCache(canonicalByUrlStore, value);
+		} catch (e) {
+			console.error(e);
+			console.error("Error updating cached canonical");
+		}
+
+		return value;
+	};
+
+	const search = async (
+		kind: "primitive-type" | "complex-type" | "resource",
+	): Promise<Resource[]> => {
+		let value: Resource[] | undefined;
+		try {
+			value = await tryCache<Resource[]>(canonicalsByKindStore, kind);
+		} catch (e) {
+			console.error(e);
+			console.error("Error checking cached canonicals by type");
+			value = undefined;
+		}
+
+		if (value !== undefined) {
+			return value ?? [];
+		}
+
+		value = await opts.search(kind);
+
+		try {
+			await updateCache(canonicalsByKindStore, value, kind);
+		} catch (e) {
+			console.error(e);
+			console.error("Error updating cached canonicals by type");
+		}
+
+		return value;
+	};
+
+	return { ...opts, search: search, resolve: resolve };
+}

--- a/packages/aidbox-fhirpath-lsp/src/index.ts
+++ b/packages/aidbox-fhirpath-lsp/src/index.ts
@@ -1,0 +1,3 @@
+export { createCodeMirrorLsp, useCodeMirrorLsp } from "./hooks";
+export { wrapCache } from "./idb-cache";
+export { startServer, terminateServer } from "./wrapper";

--- a/packages/aidbox-fhirpath-lsp/src/messages.ts
+++ b/packages/aidbox-fhirpath-lsp/src/messages.ts
@@ -1,0 +1,56 @@
+export type Resource = {
+	[key: string]: unknown;
+	url?: string;
+	version?: string;
+	id: string;
+	resourceType: string;
+};
+
+export type MsgStart = {
+	type: "start";
+	port: MessagePort;
+};
+
+export type MsgStarted = {
+	type: "started";
+};
+
+export type MsgResolveRequest = {
+	type: "resolveRequest";
+	canonicalUrl: string;
+};
+
+export type MsgResolveResponse = {
+	type: "resolveResponse";
+	resource: Resource | null;
+};
+
+export type MsgResolveError = {
+	type: "resolveError";
+};
+
+export type MsgSearchRequest = {
+	type: "searchRequest";
+	kind: "primitive-type" | "complex-type" | "resource";
+};
+
+export type MsgSearchResponse = {
+	type: "searchResponse";
+	resources: Resource[] | null;
+};
+
+export type MsgSearchError = {
+	type: "searchError";
+};
+
+export type RequestMsg = MsgResolveRequest | MsgSearchRequest;
+export type ResponseMsg = MsgResolveResponse | MsgSearchResponse;
+export type ErrorMsg = MsgResolveError | MsgSearchError;
+export type ControlMsg = MsgStart | MsgStarted;
+
+export type Msg = RequestMsg | ResponseMsg | ControlMsg;
+
+export type NumberedMsg = (RequestMsg | ResponseMsg | ErrorMsg) & {
+	id: number;
+};
+export type WireMsg = ControlMsg | NumberedMsg;

--- a/packages/aidbox-fhirpath-lsp/src/worker.ts
+++ b/packages/aidbox-fhirpath-lsp/src/worker.ts
@@ -1,0 +1,102 @@
+import { startServer } from "@atomic-ehr/fhirpath-lsp";
+import type { NumberedMsg, RequestMsg, Resource, WireMsg } from "./messages";
+
+let seq = 0;
+let started = false;
+
+const promises: Record<
+	number,
+	[(msg: WireMsg) => void, (reason: unknown) => void]
+> = {};
+
+function query(msg: RequestMsg): Promise<WireMsg> {
+	const id = seq;
+	seq += 1;
+
+	const wireMsg: NumberedMsg = { id: id, ...msg };
+
+	self.postMessage(wireMsg);
+
+	return new Promise((resolve, reject) => {
+		promises[id] = [resolve, reject];
+	});
+}
+
+async function resolve(canonicalUrl: string): Promise<Resource | null> {
+	const msg = await query({
+		type: "resolveRequest",
+		canonicalUrl: canonicalUrl,
+	});
+
+	if (msg.type !== "resolveResponse") {
+		throw Error("resolve: unexpected response type");
+	}
+
+	return msg.resource;
+}
+
+async function search(
+	kind: "primitive-type" | "complex-type" | "resource",
+): Promise<Resource[]> {
+	const msg = await query({
+		type: "searchRequest",
+		kind: kind,
+	});
+
+	if (msg.type !== "searchResponse") {
+		throw Error("search: unexpected response type");
+	}
+
+	return msg.resources ?? [];
+}
+
+self.onmessage = (msg: MessageEvent<WireMsg>) => {
+	if (msg.data.type === "start") {
+		if (started) {
+			throw Error("Already started");
+		}
+		started = true;
+
+		startServer({
+			port: msg.data.port,
+			resolve: resolve,
+			search: search,
+		});
+	} else if (
+		msg.data.type === "resolveResponse" ||
+		msg.data.type === "searchResponse"
+	) {
+		const data = msg.data;
+		const id = data.id;
+		if (typeof id !== "number") {
+			throw Error("Bad message: id must be a number");
+		}
+
+		const promData = promises[id];
+		if (promData === undefined) {
+			throw Error("LSP desync: got message with unknown id");
+		}
+		const [resolve, _reject] = promData;
+		resolve(msg.data);
+		delete promises[msg.data.id];
+	} else if (
+		msg.data.type === "resolveError" ||
+		msg.data.type === "searchError"
+	) {
+		const data = msg.data;
+		const id = data.id;
+		if (typeof id !== "number") {
+			throw Error("Bad message: id must be a number");
+		}
+
+		const promData = promises[id];
+		if (promData === undefined) {
+			throw Error("LSP desync: got message with unknown id");
+		}
+		const [_resolve, reject] = promData;
+		reject(new Error("LSP external error: could not fetch type definition"));
+		delete promises[msg.data.id];
+	} else {
+		throw Error("Bad message: unexpected type.");
+	}
+};

--- a/packages/aidbox-fhirpath-lsp/src/wrapper.ts
+++ b/packages/aidbox-fhirpath-lsp/src/wrapper.ts
@@ -1,0 +1,79 @@
+import type { ServerOptions } from "@atomic-ehr/fhirpath-lsp";
+import type { Resource, WireMsg } from "./messages";
+
+export function startServer(opts: ServerOptions): Worker {
+	const worker = new Worker(new URL("./worker.js", import.meta.url), {
+		type: "module",
+	});
+
+	try {
+		worker.onmessage = (ev: MessageEvent<WireMsg>) => {
+			const type = ev.data.type;
+			if (type === "started") {
+				// Do nothing
+			} else if (type === "resolveRequest") {
+				const msg = ev.data;
+				const id = msg.id;
+
+				const onFulfilled = (resource: Resource | null) => {
+					const msg: WireMsg = {
+						id: id,
+						type: "resolveResponse",
+						resource: resource,
+					};
+					worker.postMessage(msg);
+				};
+
+				const onRejected = (reason: unknown) => {
+					console.error(reason);
+					const msg: WireMsg = {
+						id: id,
+						type: "resolveError",
+					};
+					worker.postMessage(msg);
+				};
+
+				opts.resolve(msg.canonicalUrl).then(onFulfilled, onRejected);
+			} else if (type === "searchRequest") {
+				const msg = ev.data;
+				const id = msg.id;
+
+				const onFulfilled = (resources: Resource[]) => {
+					const msg: WireMsg = {
+						id: id,
+						type: "searchResponse",
+						resources: resources,
+					};
+					worker.postMessage(msg);
+				};
+
+				const onRejected = (reason: unknown) => {
+					console.error(reason);
+					const msg: WireMsg = {
+						id: id,
+						type: "searchError",
+					};
+					worker.postMessage(msg);
+				};
+
+				opts.search(msg.kind).then(onFulfilled, onRejected);
+			}
+		};
+
+		const port = opts.port;
+		const startCommand: WireMsg = {
+			type: "start",
+			port: port,
+		};
+
+		worker.postMessage(startCommand, [port]);
+		return worker;
+	} catch (e) {
+		worker.terminate();
+		throw e;
+	}
+}
+
+export function terminateServer(worker: Worker): void {
+	worker.terminate();
+}

--- a/packages/aidbox-fhirpath-lsp/tsconfig.app.json
+++ b/packages/aidbox-fhirpath-lsp/tsconfig.app.json
@@ -1,0 +1,39 @@
+{
+	"compilerOptions": {
+		"composite": true,
+		"declaration": true,
+		"sourceMap": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"target": "ES2023",
+		"lib": ["ES2023", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"skipLibCheck": true,
+		"isolatedDeclarations": true,
+		"types": [],
+
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"verbatimModuleSyntax": true,
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+
+		/* Linting */
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true,
+		"outDir": "dist",
+		"emitDeclarationOnly": true,
+		"declarationMap": true,
+
+		"baseUrl": ".",
+		"paths": {
+			"#shadcn/*": ["./src/shadcn/*"]
+		}
+	},
+	"include": ["src"]
+}

--- a/packages/aidbox-fhirpath-lsp/tsconfig.json
+++ b/packages/aidbox-fhirpath-lsp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.app.json" },
+		{ "path": "./tsconfig.node.json" }
+	],
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"#shadcn/*": ["./src/shadcn/*"]
+		}
+	}
+}

--- a/packages/aidbox-fhirpath-lsp/tsconfig.node.json
+++ b/packages/aidbox-fhirpath-lsp/tsconfig.node.json
@@ -1,0 +1,28 @@
+{
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+		"target": "ES2023",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"skipLibCheck": true,
+		"types": [],
+
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+
+		/* Linting */
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true
+	},
+	"include": ["vite.config.ts", "scripts/*"]
+}

--- a/packages/aidbox-fhirpath-lsp/vite.config.ts
+++ b/packages/aidbox-fhirpath-lsp/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	build: {
+		lib: {
+			entry: ["./src/worker.ts"],
+			name: "AidboxFhirPath",
+			formats: ["iife"],
+		},
+		minify: true,
+	},
+});

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -30,7 +30,7 @@
 		"tsc:check": "tsc -b --noEmit"
 	},
 	"dependencies": {
-		"@codemirror/autocomplete": "^6.18.6",
+		"@codemirror/autocomplete": "^6.20.0",
 		"@codemirror/commands": "^6.8.1",
 		"@codemirror/lang-json": "^6.0.2",
 		"@codemirror/lang-yaml": "^6.1.2",
@@ -39,7 +39,7 @@
 		"@codemirror/lint": "^6.8.5",
 		"@codemirror/search": "^6.5.11",
 		"@codemirror/state": "^6.5.2",
-		"@codemirror/view": "^6.38.1",
+		"@codemirror/view": "^6.38.8",
 		"@headless-tree/core": "^1.4.0",
 		"@headless-tree/react": "^1.4.0",
 		"@hookform/resolvers": "^5.2.1",

--- a/packages/react-components/src/components/code-editor/index.tsx
+++ b/packages/react-components/src/components/code-editor/index.tsx
@@ -18,7 +18,7 @@ import {
 } from "@codemirror/language";
 import { linter, lintGutter, lintKeymap } from "@codemirror/lint";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
-import { Compartment, EditorState } from "@codemirror/state";
+import { Compartment, EditorState, type Extension } from "@codemirror/state";
 import {
 	crosshairCursor,
 	drawSelection,
@@ -260,6 +260,7 @@ type CodeEditorProps = {
 	id?: string;
 	mode?: LanguageMode;
 	viewCallback?: (view: EditorView) => void;
+	additionalExtensions?: Extension[];
 };
 
 export type CodeEditorView = EditorView;
@@ -274,6 +275,7 @@ export function CodeEditor({
 	id,
 	mode = "json",
 	isReadOnlyTheme = false,
+	additionalExtensions,
 }: CodeEditorProps) {
 	const domRef = React.useRef(null);
 	const [view, setView] = React.useState<EditorView | null>(null);
@@ -285,6 +287,7 @@ export function CodeEditor({
 	const languageCompartment = React.useRef(new Compartment());
 	const readOnlyCompartment = React.useRef(new Compartment());
 	const themeCompartment = React.useRef(new Compartment());
+	const additionalExtensionsCompartment = React.useRef(new Compartment());
 
 	React.useEffect(() => {
 		if (!domRef.current) {
@@ -328,6 +331,7 @@ export function CodeEditor({
 					lintGutter(),
 					onChangeComparment.current.of([]),
 					onUpdateComparment.current.of([]),
+					additionalExtensionsCompartment.current.of([]),
 				],
 			}),
 		});
@@ -424,6 +428,19 @@ export function CodeEditor({
 			],
 		});
 	}, [isReadOnlyTheme, view]);
+
+	React.useEffect(() => {
+		if (view === null) {
+			return;
+		}
+		view.dispatch({
+			effects: [
+				additionalExtensionsCompartment.current.reconfigure(
+					additionalExtensions ?? [],
+				),
+			],
+		});
+	}, [additionalExtensions, view]);
 
 	return <div className="h-full w-full" ref={domRef} id={id} />;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,11 +43,84 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.2.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)
 
+  packages/aidbox-fhirpath-lsp:
+    dependencies:
+      '@atomic-ehr/fhirpath':
+        specifier: 0.0.5
+        version: 0.0.5(typescript@5.8.3)
+      '@atomic-ehr/fhirpath-lsp':
+        specifier: 0.0.2
+        version: 0.0.2(typescript@5.8.3)
+      '@health-samurai/aidbox-client':
+        specifier: workspace:*
+        version: link:../aidbox-client
+      react:
+        specifier: ^19.1.0
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.1(react@19.1.1)
+    devDependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.0
+        version: 6.20.0
+      '@codemirror/commands':
+        specifier: ^6.8.1
+        version: 6.8.1
+      '@codemirror/language':
+        specifier: ^6.11.3
+        version: 6.11.3
+      '@codemirror/lint':
+        specifier: ^6.8.5
+        version: 6.8.5
+      '@codemirror/lsp-client':
+        specifier: ^6.2.0
+        version: 6.2.1
+      '@codemirror/search':
+        specifier: ^6.5.11
+        version: 6.5.11
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.5.2
+      '@codemirror/theme-one-dark':
+        specifier: ^6.1.3
+        version: 6.1.3
+      '@codemirror/view':
+        specifier: ^6.38.1
+        version: 6.38.8
+      '@swc/cli':
+        specifier: ^0.7.8
+        version: 0.7.8(@swc/core@1.13.5)(chokidar@4.0.3)
+      '@swc/core':
+        specifier: ^1.13.5
+        version: 1.13.5
+      '@types/react':
+        specifier: ^19.1.9
+        version: 19.1.9
+      chokidar:
+        specifier: ^4.0.3
+        version: 4.0.3
+      tsdown:
+        specifier: ^0.16.6
+        version: 0.16.8(typescript@5.8.3)
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^7.0.6
+        version: 7.0.6(@types/node@24.2.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.2.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)
+
   packages/react-components:
     dependencies:
       '@codemirror/autocomplete':
-        specifier: ^6.18.6
-        version: 6.18.6
+        specifier: ^6.20.0
+        version: 6.20.0
       '@codemirror/commands':
         specifier: ^6.8.1
         version: 6.8.1
@@ -73,8 +146,8 @@ importers:
         specifier: ^6.5.2
         version: 6.5.2
       '@codemirror/view':
-        specifier: ^6.38.1
-        version: 6.38.1
+        specifier: ^6.38.8
+        version: 6.38.8
       '@headless-tree/core':
         specifier: ^1.4.0
         version: 1.4.0
@@ -303,14 +376,38 @@ packages:
     resolution: {integrity: sha512-8iRemltjVC3QGXwS2FLVD7jQDZ4QWcv1cWdcPjlIBZwwpN+MhNwv5mUiGaNOGGBdCjs3JmhDv98+0BDWUC0OSw==}
     hasBin: true
 
+  '@atomic-ehr/fhir-canonical-manager@0.0.11':
+    resolution: {integrity: sha512-BaAYcvHJWQ3uvWr77lZ20XWZ3EtxEbuEhPPpiwlpEWwrCUAnx+xYf4BZicIE7tHe3uBG5uP1XLk6ZQ30edLf5A==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5
+
   '@atomic-ehr/fhir-canonical-manager@0.0.15':
     resolution: {integrity: sha512-hVtvJrs7NjSuDx8RiUpEglaF3PuKESGRNslvEtsIl6cThnwSdovTCo+LgKD8u3W0aMdq0Dpbah9ISvkeB9+ASw==}
     hasBin: true
     peerDependencies:
       typescript: ^5
 
+  '@atomic-ehr/fhirpath-lsp@0.0.2':
+    resolution: {integrity: sha512-Gemz36k8YLvWEGyFcNko6JkCU3UHL0CpQwSIkL/LC6HAdcetogfyNW20oX7Jf8Vcwr0DG1bqBzTPF6fDd6f/1w==}
+
+  '@atomic-ehr/fhirpath@0.0.5':
+    resolution: {integrity: sha512-H7px0lpuazIioXTiHspM3wcTxRE8Fobx92tEPexbaxOpo7qzLgPoQP9hQUqTZMXmfF4kUf0nMs48/eX+jDLcYQ==}
+    peerDependencies:
+      typescript: ^5
+
+  '@atomic-ehr/fhirschema@0.0.2':
+    resolution: {integrity: sha512-OA4CVjTUEdw43Efg5I5rj95je4GC3lRiLM/kUqadcK3Po24vnINUsB8YdOP/F3ffdUYKQcJ+z09sWQVeAC2z/A==}
+    peerDependencies:
+      typescript: ^5
+
   '@atomic-ehr/fhirschema@0.0.5':
     resolution: {integrity: sha512-B/8ScNnnQUIR6d3FsIuGGvanOyE2j7W3mAubVmpPE2I/tho+meEBRrGgs5E+AY4jDz9mviTdOta08RpIhH2kew==}
+    peerDependencies:
+      typescript: ^5
+
+  '@atomic-ehr/ucum@0.2.5':
+    resolution: {integrity: sha512-AJG6RiSubIzQ1zcJosDQOJ8hXZVIWff09q8JN9Yvsi+1npPeRCLAREOOR16SNJLaGzXEDtYc8N8jhEWRA3BtXA==}
     peerDependencies:
       typescript: ^5
 
@@ -328,6 +425,10 @@ packages:
 
   '@babel/generator@7.28.0':
     resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.5':
+    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.27.2':
@@ -356,6 +457,10 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -366,6 +471,11 @@ packages:
 
   '@babel/parser@7.28.0':
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -387,6 +497,10 @@ packages:
 
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.1.3':
@@ -445,8 +559,8 @@ packages:
   '@borewit/text-codec@0.1.1':
     resolution: {integrity: sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==}
 
-  '@codemirror/autocomplete@6.18.6':
-    resolution: {integrity: sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==}
+  '@codemirror/autocomplete@6.20.0':
+    resolution: {integrity: sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==}
 
   '@codemirror/commands@6.8.1':
     resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
@@ -466,17 +580,32 @@ packages:
   '@codemirror/lint@6.8.5':
     resolution: {integrity: sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==}
 
+  '@codemirror/lsp-client@6.2.1':
+    resolution: {integrity: sha512-fjEkEc+H0kG60thaybj5+UpSnt49yAaTzOLSYZC2wlhwNAtDsWO2uZnE2AXiRGQxBVDQBvVj01MsX3F/0Vivjg==}
+
   '@codemirror/search@6.5.11':
     resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
 
   '@codemirror/state@6.5.2':
     resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
 
-  '@codemirror/view@6.38.1':
-    resolution: {integrity: sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==}
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.38.8':
+    resolution: {integrity: sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@emnapi/core@1.7.1':
+    resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
+
+  '@emnapi/runtime@1.7.1':
+    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.25.8':
     resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
@@ -831,6 +960,16 @@ packages:
     resolution: {integrity: sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==}
     engines: {node: '>= 10'}
 
+  '@napi-rs/wasm-runtime@1.0.7':
+    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
+
+  '@oxc-project/runtime@0.99.0':
+    resolution: {integrity: sha512-8iE5/4OK0SLHqWzRxSvI1gjFPmIH6718s8iwkuco95rBZsCZIHq+5wy4lYsASxnH+8FOhbGndiUrcwsVG5i2zw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.99.0':
+    resolution: {integrity: sha512-LLDEhXB7g1m5J+woRSgfKsFPS3LhR9xRhTeIoEBm5WrkwMxn6eZ0Ld0c0K5eHB57ChZX6I3uSmmLjZ8pcjlRcw==}
+
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
     engines: {node: '>= 10.0.0'}
@@ -916,6 +1055,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@quansync/fs@0.1.5':
+    resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1944,8 +2086,94 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.52':
+    resolution: {integrity: sha512-MBGIgysimZPqTDcLXI+i9VveijkP5C3EAncEogXhqfax6YXj1Tr2LY3DVuEOMIjWfMPMhtQSPup4fSTAmgjqIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.52':
+    resolution: {integrity: sha512-MmKeoLnKu1d9j6r19K8B+prJnIZ7u+zQ+zGQ3YHXGnr41rzE3eqQLovlkvoZnRoxDGPA4ps0pGiwXy6YE3lJyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.52':
+    resolution: {integrity: sha512-qpHedvQBmIjT8zdnjN3nWPR2qjQyJttbXniCEKKdHeAbZG9HyNPBUzQF7AZZGwmS9coQKL+hWg9FhWzh2dZ2IA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.52':
+    resolution: {integrity: sha512-dDp7WbPapj/NVW0LSiH/CLwMhmLwwKb3R7mh2kWX+QW85X1DGVnIEyKh9PmNJjB/+suG1dJygdtdNPVXK1hylg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.52':
+    resolution: {integrity: sha512-9e4l6vy5qNSliDPqNfR6CkBOAx6PH7iDV4OJiEJzajajGrVy8gc/IKKJUsoE52G8ud8MX6r3PMl97NfwgOzB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.52':
+    resolution: {integrity: sha512-V48oDR84feRU2KRuzpALp594Uqlx27+zFsT6+BgTcXOtu7dWy350J1G28ydoCwKB+oxwsRPx2e7aeQnmd3YJbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.52':
+    resolution: {integrity: sha512-ENLmSQCWqSA/+YN45V2FqTIemg7QspaiTjlm327eUAMeOLdqmSOVVyrQexJGNTQ5M8sDYCgVAig2Kk01Ggmqaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.52':
+    resolution: {integrity: sha512-klahlb2EIFltSUubn/VLjuc3qxp1E7th8ukayPfdkcKvvYcQ5rJztgx8JsJSuAKVzKtNTqUGOhy4On71BuyV8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.52':
+    resolution: {integrity: sha512-UuA+JqQIgqtkgGN2c/AQ5wi8M6mJHrahz/wciENPTeI6zEIbbLGoth5XN+sQe2pJDejEVofN9aOAp0kaazwnVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.52':
+    resolution: {integrity: sha512-1BNQW8u4ro8bsN1+tgKENJiqmvc+WfuaUhXzMImOVSMw28pkBKdfZtX2qJPADV3terx+vNJtlsgSGeb3+W6Jiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.52':
+    resolution: {integrity: sha512-K/p7clhCqJOQpXGykrFaBX2Dp9AUVIDHGc+PtFGBwg7V+mvBTv/tsm3LC3aUmH02H2y3gz4y+nUTQ0MLpofEEg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.52':
+    resolution: {integrity: sha512-a4EkXBtnYYsKipjS7QOhEBM4bU5IlR9N1hU+JcVEVeuTiaslIyhWVKsvf7K2YkQHyVAJ+7/A9BtrGqORFcTgng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.52':
+    resolution: {integrity: sha512-5ZXcYyd4GxPA6QfbGrNcQjmjbuLGvfz6728pZMsQvGHI+06LT06M6TPtXvFvLgXtexc+OqvFe1yAIXJU1gob/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.52':
+    resolution: {integrity: sha512-tzpnRQXJrSzb8Z9sm97UD3cY0toKOImx+xRKsDLX4zHaAlRXWh7jbaKBePJXEN7gNw7Nm03PBNwphdtA8KSUYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rolldown/pluginutils@1.0.0-beta.52':
+    resolution: {integrity: sha512-/L0htLJZbaZFL1g9OHOblTxbCYIGefErJjtYOwgl9ZqNx27P3L0SDfjhhHIss32gu5NWgnxuT2a2Hnnv6QGHKA==}
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -2348,6 +2576,9 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2527,6 +2758,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
+    engines: {node: '>=14'}
+
   arch@3.0.0:
     resolution: {integrity: sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==}
 
@@ -2547,6 +2782,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-kit@2.2.0:
+    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
+    engines: {node: '>=20.19.0'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -2575,6 +2814,9 @@ packages:
   bin-version@6.0.0:
     resolution: {integrity: sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==}
     engines: {node: '>=12'}
+
+  birpc@2.8.0:
+    resolution: {integrity: sha512-Bz2a4qD/5GRhiHSwj30c/8kC8QGj12nNDwz3D4ErQ4Xhy35dsSDvF+RA/tWpjyU0pdGtSDiEk6B5fBGE1qNVhw==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -2621,6 +2863,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -2641,6 +2887,9 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2775,6 +3024,10 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  diff@8.0.2:
+    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
+
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
@@ -2787,6 +3040,15 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dts-resolver@2.1.3:
+    resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2815,6 +3077,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -2881,6 +3147,10 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-xml-parser@5.3.2:
+    resolution: {integrity: sha512-n8v8b6p4Z1sMgqRmqLJm3awW4NX7NkaKPfb3uJIBTSH7Pdvufi3PQ3/lJLQrvxcMYl7JI2jnDO90siPEpD8JBA==}
+    hasBin: true
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
@@ -2965,6 +3235,9 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
@@ -2979,6 +3252,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -3190,8 +3466,16 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
     hasBin: true
 
   mdurl@2.0.0:
@@ -3280,6 +3564,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -3356,6 +3643,9 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -3465,6 +3755,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -3498,6 +3792,30 @@ packages:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
 
+  rolldown-plugin-dts@0.18.1:
+    resolution: {integrity: sha512-uIgNMix6OI+6bSkw0nw6O+G/ydPRCWKwvvcEyL6gWkVkSFVGWWO23DX4ZYVOqC7w5u2c8uPY9Q74U0QCKvegFA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-beta.51
+      typescript: ^5.0.0
+      vue-tsc: ~3.1.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0-beta.52:
+    resolution: {integrity: sha512-Hbnpljue+JhMJrlOjQ1ixp9me7sUec7OjFvS+A1Qm8k8Xyxmw3ZhxFu7LlSXW1s9AX3POE9W9o2oqCEeR5uDmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.46.2:
     resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3527,6 +3845,11 @@ packages:
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3638,6 +3961,9 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
+  strnum@2.1.1:
+    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
+
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
@@ -3681,6 +4007,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
@@ -3709,6 +4039,10 @@ packages:
     resolution: {integrity: sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==}
     engines: {node: '>=14.16'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -3716,6 +4050,31 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tsdown@0.16.8:
+    resolution: {integrity: sha512-6ANw9mgU9kk7SvTBKvpDu/DVJeAFECiLUSeL5M7f5Nm5H97E7ybxmXT4PQ23FySYn32y6OzjoAH/lsWCbGzfLA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@vitejs/devtools': ^0.0.0-alpha.18
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3750,6 +4109,9 @@ packages:
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
+  unconfig-core@7.4.1:
+    resolution: {integrity: sha512-Bp/bPZjV2Vl/fofoA2OYLSnw1Z0MOhCX7zHnVCYrazpfZvseBbGhwcNQMxsg185Mqh7VZQqK3C8hFG/Dyng+yA==}
+
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
@@ -3760,6 +4122,16 @@ packages:
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
+
+  unrun@0.2.15:
+    resolution: {integrity: sha512-UZ653WcLSK33meAX3nHXgD1JJ+t4RGa8WIzv9Dr4Y5ahhILZ5UIvObkVauKmtwwZ8Lsin3hUfso2UlzIwOiCNA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -3874,6 +4246,23 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -3968,11 +4357,48 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@atomic-ehr/fhir-canonical-manager@0.0.11(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@atomic-ehr/fhir-canonical-manager@0.0.15(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
+  '@atomic-ehr/fhirpath-lsp@0.0.2(typescript@5.8.3)':
+    dependencies:
+      '@atomic-ehr/fhirpath': 0.0.5(typescript@5.8.3)
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/commands': 6.8.1
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.8.5
+      '@codemirror/search': 6.5.11
+      '@codemirror/state': 6.5.2
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.38.8
+      codemirror: 6.0.2
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+    transitivePeerDependencies:
+      - typescript
+
+  '@atomic-ehr/fhirpath@0.0.5(typescript@5.8.3)':
+    dependencies:
+      '@atomic-ehr/fhir-canonical-manager': 0.0.11(typescript@5.8.3)
+      '@atomic-ehr/fhirschema': 0.0.2(typescript@5.8.3)
+      '@atomic-ehr/ucum': 0.2.5(typescript@5.8.3)
+      fast-xml-parser: 5.3.2
+      typescript: 5.8.3
+
+  '@atomic-ehr/fhirschema@0.0.2(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@atomic-ehr/fhirschema@0.0.5(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
+  '@atomic-ehr/ucum@0.2.5(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
@@ -4012,6 +4438,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.1.0
 
+  '@babel/generator@7.28.5':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
+      jsesc: 3.1.0
+
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
       '@babel/compat-data': 7.28.0
@@ -4042,6 +4476,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.28.2':
@@ -4052,6 +4488,10 @@ snapshots:
   '@babel/parser@7.28.0':
     dependencies:
       '@babel/types': 7.28.2
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
 
   '@babel/runtime@7.28.2': {}
 
@@ -4079,6 +4519,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@biomejs/biome@2.1.3':
     optionalDependencies:
@@ -4117,18 +4562,18 @@ snapshots:
 
   '@borewit/text-codec@0.1.1': {}
 
-  '@codemirror/autocomplete@6.18.6':
+  '@codemirror/autocomplete@6.20.0':
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.8
       '@lezer/common': 1.2.3
 
   '@codemirror/commands@6.8.1':
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.8
       '@lezer/common': 1.2.3
 
   '@codemirror/lang-json@6.0.2':
@@ -4138,7 +4583,7 @@ snapshots:
 
   '@codemirror/lang-sql@6.10.0':
     dependencies:
-      '@codemirror/autocomplete': 6.18.6
+      '@codemirror/autocomplete': 6.20.0
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.2.3
@@ -4147,7 +4592,7 @@ snapshots:
 
   '@codemirror/lang-yaml@6.1.2':
     dependencies:
-      '@codemirror/autocomplete': 6.18.6
+      '@codemirror/autocomplete': 6.20.0
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.2.3
@@ -4158,7 +4603,7 @@ snapshots:
   '@codemirror/language@6.11.3':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.8
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -4167,20 +4612,38 @@ snapshots:
   '@codemirror/lint@6.8.5':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.8
       crelt: 1.0.6
+
+  '@codemirror/lsp-client@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.8.5
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.8
+      '@lezer/highlight': 1.2.1
+      marked: 15.0.12
+      vscode-languageserver-protocol: 3.17.5
 
   '@codemirror/search@6.5.11':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.8
       crelt: 1.0.6
 
   '@codemirror/state@6.5.2':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.38.1':
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.8
+      '@lezer/highlight': 1.2.1
+
+  '@codemirror/view@6.38.8':
     dependencies:
       '@codemirror/state': 6.5.2
       crelt: 1.0.6
@@ -4188,6 +4651,22 @@ snapshots:
       w3c-keyname: 2.2.8
 
   '@date-fns/tz@1.4.1': {}
+
+  '@emnapi/core@1.7.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.25.8':
     optional: true
@@ -4448,6 +4927,17 @@ snapshots:
       '@napi-rs/nice-win32-x64-msvc': 1.1.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.0.7':
+    dependencies:
+      '@emnapi/core': 1.7.1
+      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/runtime@0.99.0': {}
+
+  '@oxc-project/types@0.99.0': {}
+
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
 
@@ -4510,6 +5000,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@quansync/fs@0.1.5':
+    dependencies:
+      quansync: 0.2.11
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5704,7 +6198,53 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.52':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.52':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.52':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.52': {}
 
   '@rollup/pluginutils@5.2.0(rollup@4.46.2)':
     dependencies:
@@ -6063,6 +6603,11 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -6291,6 +6836,8 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  ansis@4.2.0: {}
+
   arch@3.0.0: {}
 
   argparse@2.0.1: {}
@@ -6306,6 +6853,11 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  ast-kit@2.2.0:
+    dependencies:
+      '@babel/parser': 7.28.5
+      pathe: 2.0.3
 
   ast-types@0.16.1:
     dependencies:
@@ -6334,6 +6886,8 @@ snapshots:
     dependencies:
       execa: 5.1.1
       find-versions: 5.1.0
+
+  birpc@2.8.0: {}
 
   brace-expansion@2.0.2:
     dependencies:
@@ -6387,6 +6941,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
@@ -6412,6 +6970,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/commands': 6.8.1
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.8.5
+      '@codemirror/search': 6.5.11
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.8
 
   color-convert@2.0.1:
     dependencies:
@@ -6509,6 +7077,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  diff@8.0.2: {}
+
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
@@ -6521,6 +7091,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.2
       csstype: 3.1.3
+
+  dts-resolver@2.1.3: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -6543,6 +7115,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  empathic@2.0.0: {}
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -6630,6 +7204,10 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
+  fast-xml-parser@5.3.2:
+    dependencies:
+      strnum: 2.1.1
+
   fdir@6.4.6(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -6695,6 +7273,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob@10.4.5:
     dependencies:
       foreground-child: 3.3.1
@@ -6723,6 +7305,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hookable@5.5.3: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -6879,6 +7463,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   markdown-it@14.1.0:
     dependencies:
       argparse: 2.0.1
@@ -6887,6 +7475,8 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  marked@15.0.12: {}
 
   mdurl@2.0.0: {}
 
@@ -6943,6 +7533,8 @@ snapshots:
       path-key: 3.1.1
 
   object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
 
   onetime@5.1.2:
     dependencies:
@@ -7012,6 +7604,8 @@ snapshots:
       react-is: 16.13.1
 
   punycode.js@2.3.1: {}
+
+  quansync@0.2.11: {}
 
   quick-lru@5.1.1: {}
 
@@ -7172,6 +7766,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  readdirp@5.0.0: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -7216,6 +7812,43 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
+  rolldown-plugin-dts@0.18.1(rolldown@1.0.0-beta.52)(typescript@5.8.3):
+    dependencies:
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      ast-kit: 2.2.0
+      birpc: 2.8.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.13.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown@1.0.0-beta.52:
+    dependencies:
+      '@oxc-project/types': 0.99.0
+      '@rolldown/pluginutils': 1.0.0-beta.52
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.52
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.52
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.52
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.52
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.52
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.52
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.52
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.52
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.52
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.52
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.52
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.52
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.52
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.52
+
   rollup@4.46.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -7259,6 +7892,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
+
+  semver@7.7.3: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -7373,6 +8008,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strnum@2.1.1: {}
+
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -7414,6 +8051,8 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
@@ -7440,6 +8079,8 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tree-kill@1.2.2: {}
+
   ts-dedent@2.2.0: {}
 
   tsconfig-paths@4.2.0:
@@ -7447,6 +8088,32 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsdown@0.16.8(typescript@5.8.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      chokidar: 5.0.0
+      diff: 8.0.2
+      empathic: 2.0.0
+      hookable: 5.5.3
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.52
+      rolldown-plugin-dts: 0.18.1(rolldown@1.0.0-beta.52)(typescript@5.8.3)
+      semver: 7.7.3
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig-core: 7.4.1
+      unrun: 0.2.15
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
 
   tslib@2.8.1: {}
 
@@ -7479,6 +8146,11 @@ snapshots:
       buffer: 5.7.1
       through: 2.3.8
 
+  unconfig-core@7.4.1:
+    dependencies:
+      '@quansync/fs': 0.1.5
+      quansync: 0.2.11
+
   undici-types@7.10.0: {}
 
   unicorn-magic@0.1.0: {}
@@ -7487,6 +8159,11 @@ snapshots:
     dependencies:
       acorn: 8.15.0
       webpack-virtual-modules: 0.6.2
+
+  unrun@0.2.15:
+    dependencies:
+      '@oxc-project/runtime': 0.99.0
+      rolldown: 1.0.0-beta.52
 
   update-browserslist-db@1.1.3(browserslist@4.25.2):
     dependencies:
@@ -7616,6 +8293,21 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new Aidbox FHIRPath LSP package (CodeMirror + WebWorker + IndexedDB cache) and updates CodeEditor to accept additional CodeMirror extensions, with minor CodeMirror version bumps.
> 
> - **New package `packages/aidbox-fhirpath-lsp`**:
>   - CodeMirror LSP integration for FHIRPath using `@atomic-ehr/fhirpath-lsp` and Aidbox client.
>   - WebWorker-based server (`src/worker.ts`) with message wrapper (`src/wrapper.ts`) and typed messages (`src/messages.ts`).
>   - IndexedDB-backed cache layer (`src/idb-cache.ts`).
>   - React hooks/API (`createCodeMirrorLsp`, `useCodeMirrorLsp`) to attach LSP to editors.
>   - Example app (`example/main.ts`, `index.html`) and build/config files (`vite.config.ts`, `tsconfig*`, `.swcrc`, `biome.json`).
> - **React Components** (`packages/react-components`):
>   - `CodeEditor`: new `additionalExtensions?: Extension[]` prop; wiring via a dedicated compartment.
>   - Dependencies: bump `@codemirror/autocomplete` and `@codemirror/view`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59d395872ef6b0360522d7c7e9a04b979b04e57d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->