### PR TITLE
Switch to trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,5 +37,3 @@ jobs:
       - name: Publish
         run: |
           pnpm -r publish --tag ${{ github.event.inputs.dist_tag }} --publish-branch master
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update the release workflow to use OIDC trusted publishing by granting `id-token` and removing the `NODE_AUTH_TOKEN` env from publish.
> 
> - **CI/CD (GitHub Actions)**:
>   - Update `/.github/workflows/release.yaml` to use trusted publishing for npm:
>     - Add `permissions: id-token: write`.
>     - Remove `NODE_AUTH_TOKEN` environment from the `Publish` step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4580abc316c3f197d8d664da2db323b1fad3914c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->