### PR TITLE
change aidbox-fhirpath-lsp packaging format

### DIFF
--- a/packages/aidbox-fhirpath-lsp/example/main.ts
+++ b/packages/aidbox-fhirpath-lsp/example/main.ts
@@ -29,7 +29,7 @@ import {
 	rectangularSelection,
 } from "@codemirror/view";
 import {
-	type AidboxClient,
+	AidboxClient,
 	type AuthProvider,
 	BrowserAuthProvider,
 } from "@health-samurai/aidbox-client";
@@ -46,7 +46,7 @@ const contextTypeSelect = document.getElementById(
 ) as HTMLSelectElement;
 const initialContextType = contextTypeSelect?.value || "Patient";
 
-const aidboxUrl = "http://localhost:8080";
+const aidboxUrl = "http://localhost:8765";
 const authProvider: AuthProvider = new BrowserAuthProvider(aidboxUrl);
 const client: AidboxClient = new AidboxClient(aidboxUrl, authProvider);
 

--- a/packages/aidbox-fhirpath-lsp/package.json
+++ b/packages/aidbox-fhirpath-lsp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@health-samurai/aidbox-fhirpath-lsp",
-	"version": "0.0.0-alpha.2",
+	"version": "0.0.0-alpha.3",
 	"type": "module",
 	"files": [
 		"dist",
@@ -13,7 +13,7 @@
 		}
 	},
 	"scripts": {
-		"build": "rm -rf dist && mkdir -p dist && swc src -d dist -D && tsc -b --force && echo success",
+		"build": "rm -rf dist && mkdir -p dist && swc src -d dist -D && tsc -b --force && vite build && echo success",
 		"build:watch": "tsx scripts/watch.node.ts",
 		"format": "biome format",
 		"format:check": "biome format",
@@ -26,7 +26,11 @@
 	"dependencies": {
 		"@atomic-ehr/fhirpath": "0.0.5",
 		"@atomic-ehr/fhirpath-lsp": "0.0.2",
-		"@health-samurai/aidbox-client": "workspace:*",
+		"@health-samurai/aidbox-client": "workspace:^"
+	},
+	"peerDependencies": {
+		"@codemirror/lsp-client": "^6.2.0",
+		"@codemirror/state": "^6.5.2",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0"
 	},

--- a/packages/aidbox-fhirpath-lsp/vite.config.ts
+++ b/packages/aidbox-fhirpath-lsp/vite.config.ts
@@ -3,10 +3,18 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	build: {
 		lib: {
-			entry: ["./src/worker.ts"],
-			name: "AidboxFhirPath",
-			formats: ["iife"],
+			entry: "./src/worker.ts",
+			formats: ["es"],
+			fileName: () => "worker.js",
 		},
-		minify: true,
+		outDir: "dist/src",
+		emptyOutDir: false,
+		minify: false,
+		rollupOptions: {
+			external: [],
+			output: {
+				inlineDynamicImports: true,
+			},
+		},
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         specifier: 0.0.2
         version: 0.0.2(typescript@5.8.3)
       '@health-samurai/aidbox-client':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../aidbox-client
       react:
         specifier: ^19.1.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build/packaging changes can break downstream consumption (worker loading path/format and peer dependency expectations), but core runtime logic is largely unchanged.
> 
> **Overview**
> Updates `@health-samurai/aidbox-fhirpath-lsp` packaging by adding Vite to the build pipeline and changing the worker bundle output from an IIFE-style library build to an ES-module `worker.js` emitted into `dist/src` (without clearing the directory and with inline dynamic imports).
> 
> Adjusts dependency metadata by moving CodeMirror runtime packages to `peerDependencies` and tightening the workspace version range for `@health-samurai/aidbox-client`, and bumps the package version. The example is updated to use a different default Aidbox URL and slightly tweaks the `AidboxClient` import style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53e2d146e287c88517124cc19a9757d9f9945657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->