### PR TITLE
feat(aidbox-client): add $sql, $materialize, and flexible operations

### DIFF
--- a/packages/aidbox-client/src/client.ts
+++ b/packages/aidbox-client/src/client.ts
@@ -917,6 +917,70 @@ export class AidboxClient<
 		});
 	}
 
+	/// Aidbox-specific methods
+
+	/**
+	 * Execute a raw SQL query against the Aidbox database.
+	 *
+	 * The interaction is performed by an HTTP POST command as shown:
+	 *
+	 * ```
+	 * POST [base]/$sql
+	 * ```
+	 *
+	 * Example usage:
+	 *
+	 * ```typescript
+	 * const result = await client.sql<{ cnt: number }>(
+	 *   "SELECT count(*) as cnt FROM patient"
+	 * );
+	 * ```
+	 *
+	 * @group Aidbox methods
+	 */
+	public async sql<T>(
+		query: string,
+		params?: unknown[],
+	): Promise<Result<ResourceResponse<T[]>, ResourceResponse<TOperationOutcome>>> {
+		const body = params ? [query, ...params] : [query];
+		return await this.request<T[]>({
+			url: "/$sql",
+			method: "POST",
+			body: JSON.stringify(body),
+		});
+	}
+
+	/**
+	 * Materialize a ViewDefinition into a flat table.
+	 *
+	 * The interaction is performed by an HTTP POST command as shown:
+	 *
+	 * ```
+	 * POST [base]/fhir/ViewDefinition/[id]/$materialize
+	 * ```
+	 *
+	 * Example usage:
+	 *
+	 * ```typescript
+	 * const result = await client.materialize("view-def-id", "materialized-view");
+	 * ```
+	 *
+	 * @group Aidbox methods
+	 */
+	public async materialize(
+		viewDefinitionId: string,
+		type: "table" | "view" | "materialized-view" = "materialized-view",
+	): Promise<Result<ResourceResponse<unknown>, ResourceResponse<TOperationOutcome>>> {
+		return await this.request<unknown>({
+			url: makeUrl([basePath, "ViewDefinition", viewDefinitionId, "$materialize"]),
+			method: "POST",
+			body: JSON.stringify({
+				resourceType: "Parameters",
+				parameter: [{ name: "type", valueCode: type }],
+			}),
+		});
+	}
+
 	/**
 	 * Performs a request to `/auth/userinfo`.
 	 *

--- a/packages/aidbox-client/src/client.ts
+++ b/packages/aidbox-client/src/client.ts
@@ -32,6 +32,12 @@ import type {
 import { ErrorResponse, RequestError } from "./types";
 import { coerceBody } from "./utils";
 
+/** Result of a ViewDefinition $materialize operation. */
+export type MaterializeResult = {
+	resourceType: "Parameters";
+	parameter?: Array<{ name: string; valueString?: string; valueCode?: string }>;
+};
+
 type InternalAidboxErrorResponse = {
 	error?: unknown;
 	duration: number;
@@ -930,19 +936,29 @@ export class AidboxClient<
 	 *
 	 * Example usage:
 	 *
+	 * **Important:** Always use parameterized queries to prevent SQL injection.
+	 * Pass user-supplied values via `params`, never interpolate them into the query string.
+	 *
 	 * ```typescript
+	 * // Good — parameterized
 	 * const result = await client.sql<{ cnt: number }>(
-	 *   "SELECT count(*) as cnt FROM patient"
+	 *   "SELECT count(*) as cnt FROM patient WHERE id = ?", [patientId]
 	 * );
+	 *
+	 * // Bad — SQL injection risk
+	 * const result = await client.sql(`SELECT * FROM patient WHERE id = '${patientId}'`);
 	 * ```
+	 *
+	 * Note: `$sql` is an Aidbox-specific endpoint (not part of the FHIR spec).
+	 * The URL uses the Aidbox-native prefix (`/$sql`), not the FHIR prefix (`/fhir/$sql`).
 	 *
 	 * @group Aidbox methods
 	 */
 	public async sql<T>(
 		query: string,
-		params?: unknown[],
+		params?: Array<string | number | boolean | null>,
 	): Promise<Result<ResourceResponse<T[]>, ResourceResponse<TOperationOutcome>>> {
-		const body = params ? [query, ...params] : [query];
+		const body = params?.length ? [query, ...params] : [query];
 		return await this.request<T[]>({
 			url: "/$sql",
 			method: "POST",
@@ -970,8 +986,8 @@ export class AidboxClient<
 	public async materialize(
 		viewDefinitionId: string,
 		type: "table" | "view" | "materialized-view" = "materialized-view",
-	): Promise<Result<ResourceResponse<unknown>, ResourceResponse<TOperationOutcome>>> {
-		return await this.request<unknown>({
+	): Promise<Result<ResourceResponse<MaterializeResult>, ResourceResponse<TOperationOutcome>>> {
+		return await this.request<MaterializeResult>({
 			url: makeUrl([basePath, "ViewDefinition", viewDefinitionId, "$materialize"]),
 			method: "POST",
 			body: JSON.stringify({

--- a/packages/aidbox-client/src/client.ts
+++ b/packages/aidbox-client/src/client.ts
@@ -14,6 +14,7 @@ import type {
 	HistoryInstanceOptions,
 	HistorySystemOptions,
 	HistoryTypeOptions,
+	MaterializeResult,
 	OperationOptions,
 	PatchOptions,
 	ReadOptions,
@@ -31,7 +32,6 @@ import type {
 } from "./types";
 import { ErrorResponse, RequestError } from "./types";
 import { coerceBody } from "./utils";
-import type { MaterializeResult } from "./types";
 
 type InternalAidboxErrorResponse = {
 	error?: unknown;
@@ -952,7 +952,9 @@ export class AidboxClient<
 	public async sql<T>(
 		query: string,
 		params?: Array<string | number | boolean | null>,
-	): Promise<Result<ResourceResponse<T[]>, ResourceResponse<TOperationOutcome>>> {
+	): Promise<
+		Result<ResourceResponse<T[]>, ResourceResponse<TOperationOutcome>>
+	> {
 		const body = params?.length ? [query, ...params] : [query];
 		return await this.request<T[]>({
 			url: "/$sql",
@@ -981,9 +983,19 @@ export class AidboxClient<
 	public async materialize(
 		viewDefinitionId: string,
 		type: "table" | "view" | "materialized-view" = "materialized-view",
-	): Promise<Result<ResourceResponse<MaterializeResult>, ResourceResponse<TOperationOutcome>>> {
+	): Promise<
+		Result<
+			ResourceResponse<MaterializeResult>,
+			ResourceResponse<TOperationOutcome>
+		>
+	> {
 		return await this.request<MaterializeResult>({
-			url: makeUrl([basePath, "ViewDefinition", viewDefinitionId, "$materialize"]),
+			url: makeUrl([
+				basePath,
+				"ViewDefinition",
+				viewDefinitionId,
+				"$materialize",
+			]),
 			method: "POST",
 			body: JSON.stringify({
 				resourceType: "Parameters",

--- a/packages/aidbox-client/src/client.ts
+++ b/packages/aidbox-client/src/client.ts
@@ -31,12 +31,7 @@ import type {
 } from "./types";
 import { ErrorResponse, RequestError } from "./types";
 import { coerceBody } from "./utils";
-
-/** Result of a ViewDefinition $materialize operation. */
-export type MaterializeResult = {
-	resourceType: "Parameters";
-	parameter?: Array<{ name: string; valueString?: string; valueCode?: string }>;
-};
+import type { MaterializeResult } from "./types";
 
 type InternalAidboxErrorResponse = {
 	error?: unknown;

--- a/packages/aidbox-client/src/types.ts
+++ b/packages/aidbox-client/src/types.ts
@@ -180,12 +180,11 @@ export type HistoryTypeOptions = {
 
 export type HistorySystemOptions = Record<string, never>;
 
-// FIXME: resource -> params
 export type OperationOptions<T> = {
 	type: string;
 	id?: string;
-	operation: "$run" | "$validate";
-	resource: T;
+	operation: `$${string}`;
+	resource?: T;
 };
 
 export type ValidateOptions<T> = Omit<OperationOptions<T>, "operation">;

--- a/packages/aidbox-client/src/types.ts
+++ b/packages/aidbox-client/src/types.ts
@@ -202,6 +202,12 @@ export type BatchOptions<TBundle> = {
 	};
 };
 
+/** Result of a ViewDefinition $materialize operation. */
+export type MaterializeResult = {
+	resourceType: "Parameters";
+	parameter?: Array<{ name: string; valueString?: string; valueCode?: string }>;
+};
+
 export type TransactionOptions<TBundle> = {
 	format: string;
 	bundle: TBundle & {

--- a/packages/aidbox-client/src/types.ts
+++ b/packages/aidbox-client/src/types.ts
@@ -180,14 +180,16 @@ export type HistoryTypeOptions = {
 
 export type HistorySystemOptions = Record<string, never>;
 
-export type OperationOptions<T> = {
+export type OperationOptions<T = unknown> = {
 	type: string;
 	id?: string;
 	operation: `$${string}`;
 	resource?: T;
 };
 
-export type ValidateOptions<T> = Omit<OperationOptions<T>, "operation">;
+export type ValidateOptions<T> = Omit<OperationOptions<T>, "operation"> & {
+	resource: T;
+};
 
 export type CapabilitiesOptions = {
 	mode: "full" | "normative" | "terminology";

--- a/packages/aidbox-client/test/aidbox-extensions.test.ts
+++ b/packages/aidbox-client/test/aidbox-extensions.test.ts
@@ -1,0 +1,154 @@
+import { BasicAuthProvider } from "src/auth-providers";
+import { AidboxClient } from "src/client";
+import type { Bundle, OperationOutcome } from "src/fhir-types/hl7-fhir-r4-core";
+import type { User } from "src/types";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+function mockFetch(response: unknown, status = 200) {
+	return vi.fn().mockResolvedValue({
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: status === 200 ? "OK" : "Error",
+		headers: new Headers({ "content-type": "application/json" }),
+		json: async () => response,
+		clone: () => ({ json: async () => response }),
+	});
+}
+
+describe("Aidbox extensions", () => {
+	let client: AidboxClient<Bundle, OperationOutcome, User>;
+	const baseUrl = "http://localhost:8080";
+
+	beforeEach(() => {
+		client = new AidboxClient<Bundle, OperationOutcome, User>(
+			baseUrl,
+			new BasicAuthProvider(baseUrl, "admin", "secret"),
+		);
+	});
+
+	describe("sql", () => {
+		it("should execute a SQL query", async () => {
+			const mockRows = [{ cnt: 42 }];
+			globalThis.fetch = mockFetch(mockRows);
+
+			const result = await client.sql<{ cnt: number }>("SELECT count(*) as cnt FROM patient");
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value.resource).toEqual([{ cnt: 42 }]);
+			}
+
+			expect(fetch).toHaveBeenCalledWith(
+				`${baseUrl}/$sql`,
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify(["SELECT count(*) as cnt FROM patient"]),
+				}),
+			);
+		});
+
+		it("should pass parameters", async () => {
+			const mockRows = [{ id: "pt-1", name: "Test" }];
+			globalThis.fetch = mockFetch(mockRows);
+
+			await client.sql("SELECT * FROM patient WHERE id = ?", ["pt-1"]);
+
+			expect(fetch).toHaveBeenCalledWith(
+				`${baseUrl}/$sql`,
+				expect.objectContaining({
+					body: JSON.stringify(["SELECT * FROM patient WHERE id = ?", "pt-1"]),
+				}),
+			);
+		});
+
+		it("should return Err on server error", async () => {
+			const outcome: OperationOutcome = {
+				resourceType: "OperationOutcome",
+				issue: [{ severity: "error", code: "exception", diagnostics: "SQL error" }],
+			};
+			globalThis.fetch = mockFetch(outcome, 500);
+
+			const result = await client.sql("INVALID SQL");
+
+			expect(result.isErr()).toBe(true);
+		});
+	});
+
+	describe("materialize", () => {
+		it("should materialize a ViewDefinition", async () => {
+			const mockResult = {
+				resourceType: "Parameters",
+				parameter: [{ name: "viewName", valueString: "mira_backend.encounter_flat" }],
+			};
+			globalThis.fetch = mockFetch(mockResult);
+
+			const result = await client.materialize("vd-encounter-flat");
+
+			expect(result.isOk()).toBe(true);
+
+			expect(fetch).toHaveBeenCalledWith(
+				`${baseUrl}/fhir/ViewDefinition/vd-encounter-flat/%24materialize`,
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({
+						resourceType: "Parameters",
+						parameter: [{ name: "type", valueCode: "materialized-view" }],
+					}),
+				}),
+			);
+		});
+
+		it("should support different materialization types", async () => {
+			globalThis.fetch = mockFetch({});
+
+			await client.materialize("vd-test", "table");
+
+			expect(fetch).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					body: JSON.stringify({
+						resourceType: "Parameters",
+						parameter: [{ name: "type", valueCode: "table" }],
+					}),
+				}),
+			);
+		});
+	});
+
+	describe("operation (flexible)", () => {
+		it("should allow custom operation names", async () => {
+			globalThis.fetch = mockFetch({ result: "ok" });
+
+			const result = await client.operation({
+				type: "Patient",
+				id: "pt-1",
+				operation: "$everything",
+			});
+
+			expect(result.isOk()).toBe(true);
+			expect(fetch).toHaveBeenCalledWith(
+				`${baseUrl}/fhir/Patient/pt-1/%24everything`,
+				expect.objectContaining({ method: "POST" }),
+			);
+		});
+
+		it("should allow operation without resource body", async () => {
+			globalThis.fetch = mockFetch({ resourceType: "Parameters" });
+
+			const result = await client.operation({
+				type: "ValueSet",
+				operation: "$expand",
+			});
+
+			expect(result.isOk()).toBe(true);
+			// body should not be set when resource is undefined
+			expect(fetch).toHaveBeenCalledWith(
+				`${baseUrl}/fhir/ValueSet/%24expand`,
+				expect.objectContaining({
+					method: "POST",
+					body: null,
+				}),
+			);
+		});
+	});
+});

--- a/packages/aidbox-client/test/aidbox-extensions.test.ts
+++ b/packages/aidbox-client/test/aidbox-extensions.test.ts
@@ -2,7 +2,7 @@ import { BasicAuthProvider } from "src/auth-providers";
 import { AidboxClient } from "src/client";
 import type { Bundle, OperationOutcome } from "src/fhir-types/hl7-fhir-r4-core";
 import type { User } from "src/types";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalFetch = globalThis.fetch;
 
@@ -37,7 +37,9 @@ describe("Aidbox extensions", () => {
 			const mockRows = [{ cnt: 42 }];
 			globalThis.fetch = mockFetch(mockRows);
 
-			const result = await client.sql<{ cnt: number }>("SELECT count(*) as cnt FROM patient");
+			const result = await client.sql<{ cnt: number }>(
+				"SELECT count(*) as cnt FROM patient",
+			);
 
 			expect(result.isOk()).toBe(true);
 			if (result.isOk()) {
@@ -84,7 +86,9 @@ describe("Aidbox extensions", () => {
 		it("should return Err on server error", async () => {
 			const outcome: OperationOutcome = {
 				resourceType: "OperationOutcome",
-				issue: [{ severity: "error", code: "exception", diagnostics: "SQL error" }],
+				issue: [
+					{ severity: "error", code: "exception", diagnostics: "SQL error" },
+				],
 			};
 			globalThis.fetch = mockFetch(outcome, 500);
 
@@ -98,7 +102,9 @@ describe("Aidbox extensions", () => {
 		it("should materialize a ViewDefinition", async () => {
 			const mockResult = {
 				resourceType: "Parameters",
-				parameter: [{ name: "viewName", valueString: "mira_backend.encounter_flat" }],
+				parameter: [
+					{ name: "viewName", valueString: "mira_backend.encounter_flat" },
+				],
 			};
 			globalThis.fetch = mockFetch(mockResult);
 

--- a/packages/aidbox-client/test/aidbox-extensions.test.ts
+++ b/packages/aidbox-client/test/aidbox-extensions.test.ts
@@ -2,7 +2,9 @@ import { BasicAuthProvider } from "src/auth-providers";
 import { AidboxClient } from "src/client";
 import type { Bundle, OperationOutcome } from "src/fhir-types/hl7-fhir-r4-core";
 import type { User } from "src/types";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const originalFetch = globalThis.fetch;
 
 function mockFetch(response: unknown, status = 200) {
 	return vi.fn().mockResolvedValue({
@@ -24,6 +26,10 @@ describe("Aidbox extensions", () => {
 			baseUrl,
 			new BasicAuthProvider(baseUrl, "admin", "secret"),
 		);
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
 	});
 
 	describe("sql", () => {
@@ -57,6 +63,20 @@ describe("Aidbox extensions", () => {
 				`${baseUrl}/$sql`,
 				expect.objectContaining({
 					body: JSON.stringify(["SELECT * FROM patient WHERE id = ?", "pt-1"]),
+				}),
+			);
+		});
+
+		it("should handle empty params array", async () => {
+			const mockRows = [{ cnt: 0 }];
+			globalThis.fetch = mockFetch(mockRows);
+
+			await client.sql("SELECT 1", []);
+
+			expect(fetch).toHaveBeenCalledWith(
+				`${baseUrl}/$sql`,
+				expect.objectContaining({
+					body: JSON.stringify(["SELECT 1"]),
 				}),
 			);
 		});


### PR DESCRIPTION
## Summary

- **`sql<T>(query, params?)`** — Execute raw SQL queries against the Aidbox `/$sql` endpoint with typed results
- **`materialize(viewDefId, type?)`** — Materialize ViewDefinitions into flat tables via `$materialize`
- **Flexible `OperationOptions.operation`** — Changed from `"$run" | "$validate"` to `` `$${string}` `` to support any FHIR operation (`$everything`, `$expand`, `$validate`, etc.)
- **Optional `OperationOptions.resource`** — Some operations (e.g. `$expand`) don't require a request body

## Context

We're building [MIRA](https://github.com/cognovis/mira), a billing optimization system for German healthcare, on top of Aidbox. We use `$sql` extensively for fast indexed queries and `$materialize` for ViewDefinition-based flat tables. The hardcoded operation names were blocking us from using operations like `$validate` and `$everything` through the typed client.

## Test plan

- [x] 7 new unit tests in `test/aidbox-extensions.test.ts`
- [x] All existing unit tests still pass (33 total)
- [x] Live-tested against Aidbox instance (search, read, $sql, $sql with params, $validate)
- [x] `tsc -b --noEmit` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands and loosens operation/SQL request capabilities, which could change call-site typing expectations and enables security-sensitive SQL usage if misused, though changes are contained to client helpers and covered by unit tests.
> 
> **Overview**
> Adds Aidbox-specific convenience APIs: `client.sql()` to POST parameterized raw SQL to `/$sql`, and `client.materialize()` to invoke `ViewDefinition/$materialize` with a `Parameters` payload and typed `MaterializeResult` response.
> 
> Broadens `OperationOptions` to accept any `$...` operation name and makes the operation request body optional (while keeping `validate` requiring a resource), with new Vitest coverage for SQL, materialization, and body-less/custom operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d989a004589667e36aaee7097a96a79ccc74e12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->