### PR TITLE
ci: add pull_request trigger to workflows

### DIFF
--- a/.github/workflows/aidbox-client.yaml
+++ b/.github/workflows/aidbox-client.yaml
@@ -2,6 +2,7 @@ name: Test Aidbox Client
 
 on:
   push:
+  pull_request:
 
 jobs:
   e2e:

--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -1,6 +1,7 @@
 name: Aidbox TS SDK
 on:
   push:
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Workflows (`common.yaml`, `aidbox-client.yaml`) only had `on: push` trigger
- Required status checks (`lint`, `typecheck`, `e2e`) never ran on PRs, causing them to hang in "Pending" forever and blocking merges
- Added `pull_request` trigger to both workflow files

## Test plan
- [ ] Verify that opening/updating a PR triggers `lint`, `typecheck`, and `e2e` checks
- [ ] Verify PR #92 checks unblock after this is merged