### PR TITLE
concat base path without dropping parts of it

### DIFF
--- a/packages/aidbox-client/src/auth-providers.ts
+++ b/packages/aidbox-client/src/auth-providers.ts
@@ -6,11 +6,11 @@ export class BrowserAuthProvider implements AuthProvider {
 	public baseUrl: string;
 
 	constructor(baseUrl: string) {
-		this.baseUrl = baseUrl;
+		this.baseUrl = baseUrl.replace(/\/+$/, "");
 	}
 
 	async #checkSession() {
-		const response = await fetch(new URL("/auth/userinfo", this.baseUrl), {
+		const response = await fetch(`${this.baseUrl}/auth/userinfo`, {
 			method: "GET",
 			headers: {
 				"content-type": "application/json",
@@ -36,7 +36,7 @@ export class BrowserAuthProvider implements AuthProvider {
 	 * Sends a POST request to `baseurl/auth/logout`.
 	 */
 	public async revokeSession() {
-		await fetch(new URL("/auth/logout", this.baseUrl), {
+		await fetch(`${this.baseUrl}/auth/logout`, {
 			method: "POST",
 			headers: {
 				"content-type": "application/json",
@@ -78,7 +78,7 @@ export class BasicAuthProvider implements AuthProvider {
 	#authHeader: string;
 
 	constructor(baseUrl: string, username: string, password: string) {
-		this.baseUrl = baseUrl;
+		this.baseUrl = baseUrl.replace(/\/+$/, "");
 		// Create Base64-encoded credentials for Basic Auth header (RFC 7617: UTF-8 encoded)
 		const credentials = `${username}:${password}`;
 		const utf8Bytes = new TextEncoder().encode(credentials);

--- a/packages/aidbox-client/src/client.ts
+++ b/packages/aidbox-client/src/client.ts
@@ -31,7 +31,7 @@ import type {
 	VReadOptions,
 } from "./types";
 import { ErrorResponse, RequestError } from "./types";
-import { coerceBody } from "./utils";
+import { coerceBody, joinUrl } from "./utils";
 
 type InternalAidboxErrorResponse = {
 	error?: unknown;
@@ -91,7 +91,7 @@ export class AidboxClient<
 	public authProvider: AuthProvider;
 
 	constructor(baseUrl: string, authProvider: AuthProvider) {
-		this.baseUrl = baseUrl;
+		this.baseUrl = baseUrl.replace(/\/+$/, "");
 		this.authProvider = authProvider;
 	}
 
@@ -113,7 +113,7 @@ export class AidboxClient<
 
 		const { method, url, headers = {}, params = [], body } = requestParams;
 
-		const urlObj = new URL(url, baseUrl);
+		const urlObj = joinUrl(baseUrl, url);
 
 		params.forEach(([key, value]) => {
 			urlObj.searchParams.append(key, value);

--- a/packages/aidbox-client/src/utils.ts
+++ b/packages/aidbox-client/src/utils.ts
@@ -3,6 +3,18 @@ import type { ResponseWithMeta } from "./types";
 import { ErrorResponse } from "./types";
 
 /**
+ * Join a base URL (which may include a path component) with a path.
+ *
+ * `new URL("/foo", "http://host/bar")` drops `/bar` because absolute paths
+ * replace the entire path of the base. This preserves the base path.
+ */
+export function joinUrl(baseUrl: string, path: string): URL {
+	const base = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+	const suffix = path.startsWith("/") ? path : `/${path}`;
+	return new URL(`${base}${suffix}`);
+}
+
+/**
  * Validate that fetch input URL starts with baseUrl.
  * Throws if the URL doesn't match baseUrl.
  */


### PR DESCRIPTION
## What

alternative way to compute paths for requests that respects non-standard base-paths.

## Why

custom base path broke clients.