### PR TITLE
Support SMART App Launch

### DIFF
--- a/packages/aidbox-client/README.md
+++ b/packages/aidbox-client/README.md
@@ -336,12 +336,14 @@ For provider-facing applications that authenticate users via [SMART App Launch](
 
 The provider holds no session state of its own — your application stores the `SmartSession` (in a cookie session, Redis, `sessionStorage`, etc.) and supplies `getSession` / `setSession` callbacks. This works the same way in a browser SPA and in a server app.
 
+For confidential SMART clients, the `clientSecret` is intentionally **not** stored in `PendingAuthorization` or `SmartSession`. Persist those objects freely, but pass the secret separately in server-side code when calling `exchangeCode`, `refreshSession`, `revokeSession`, or `SmartAppLaunchAuthProvider`.
+
 `exchangeCode()` stores token endpoint data in the session. When Aidbox includes `userinfo` in the token response, it is available as `session.userinfo`.
 
 The flow has three stages, each backed by a top-level function:
 
 1. `authorize(config)` — at the launch URL, returns `{ redirectUrl, pending }`. Persist `pending` keyed by `pending.stateNonce`, then redirect the user-agent to `redirectUrl`.
-2. `exchangeCode({ url, pending })` — at the redirect URL, exchanges the `?code=...` for a `SmartSession`. Look up the previously stored `pending` using the `?state=...` query parameter.
+2. `exchangeCode({ url, pending })` — at the redirect URL, exchanges the `?code=...` for a `SmartSession`. Look up the previously stored `pending` using the `?state=...` query parameter. Confidential clients also pass `clientSecret` here.
 3. `new SmartAppLaunchAuthProvider(...)` — for subsequent FHIR requests. Adds `Authorization: Bearer ...`, refreshes proactively before expiry, retries once on 401.
 
 Features:
@@ -349,7 +351,7 @@ Features:
 - PKCE with `S256` (configurable: `ifSupported` / `required` / `disabled`)
 - Standalone and EHR launch detected by inspecting the launch URL
 - Optional `issMatch` allow-list for the resolved `iss` (CSRF-style protection)
-- Confidential clients (`clientSecret`) supported via HTTP Basic on the token endpoint
+- Confidential clients (`clientSecret`) supported via HTTP Basic on the token endpoint without persisting secrets in `pending` or `session`
 - Token refresh deduplication — concurrent FHIR requests share a single refresh
 
 #### Server-side example (Express-style pseudocode)
@@ -370,6 +372,7 @@ app.get("/launch", async (req, res) => {
   const { redirectUrl, pending } = await authorize({
     iss: "https://fhir.example.com", // fallback for standalone; query iss wins for EHR
     clientId: process.env.SMART_CLIENT_ID,
+    clientSecret: process.env.SMART_CLIENT_SECRET, // sets usesClientSecret without persisting the secret
     scope: "launch openid fhirUser patient/*.read offline_access",
     redirectUri: `${process.env.BASE_URL}/callback`,
     launchUrl: req.url, // lets the helper extract iss/launch from query params
@@ -386,7 +389,11 @@ app.get("/callback", async (req, res) => {
   const pending: PendingAuthorization = req.session.pending?.[stateNonce!];
   if (!pending) return res.status(400).send("Unknown state");
 
-  const session = await exchangeCode({ url: req.url, pending });
+  const session = await exchangeCode({
+    url: req.url,
+    pending,
+    clientSecret: process.env.SMART_CLIENT_SECRET,
+  });
 
   req.session.smart = session;
   delete req.session.pending;
@@ -402,6 +409,7 @@ app.get("/app", async (req, res) => {
     baseUrl: session.serverUrl,
     getSession: () => req.session.smart,
     setSession: (s) => { req.session.smart = s; },
+    getClientSecret: () => process.env.SMART_CLIENT_SECRET,
   });
 
   const client = new AidboxClient(session.serverUrl, auth);
@@ -412,7 +420,7 @@ app.get("/app", async (req, res) => {
 
 #### Browser SPA example
 
-The same three calls work in the browser — only the storage backend changes (here `sessionStorage`):
+The same three calls work in the browser — only the storage backend changes (here `sessionStorage`). Browser apps must use public SMART clients; confidential client secrets belong on the server only:
 
 ```typescript
 import {
@@ -460,6 +468,14 @@ import { refreshSession, revokeSession } from "@health-samurai/aidbox-client";
 
 const refreshed = await refreshSession(session);  // returns a new SmartSession
 await revokeSession(session);                     // best-effort revocation at the auth server
+
+// Confidential clients pass the secret explicitly in server-side code:
+const refreshedConfidential = await refreshSession(session, {
+  clientSecret: process.env.SMART_CLIENT_SECRET,
+});
+await revokeSession(session, {
+  clientSecret: process.env.SMART_CLIENT_SECRET,
+});
 ```
 
 > **Security note:** when scope includes `openid`, the token response carries an `id_token` JWT. This library does **not** validate the JWT signature, `iss`, `aud`, or `exp` — it stores the raw token in `session.idToken`. If you use id_token claims for authorization decisions, validate the JWT yourself first.

--- a/packages/aidbox-client/README.md
+++ b/packages/aidbox-client/README.md
@@ -264,13 +264,14 @@ Both methods can throw the `RequestError` class if the error happened before the
 
 ## Authentication Providers
 
-Authentication is managed via the `AuthProvider` interface. The client ships with three built-in providers:
+Authentication is managed via the `AuthProvider` interface. The client ships with four built-in providers:
 
 | Provider | Environment | Auth Method |
 |----------|-------------|-------------|
 | `BrowserAuthProvider` | Browser | Cookie-based sessions |
 | `BasicAuthProvider` | Any | HTTP Basic Auth |
 | `SmartBackendServicesAuthProvider` | Server-side | OAuth 2.0 client_credentials with JWT bearer |
+| `SmartAppLaunchAuthProvider` | Browser or server | SMART App Launch (OAuth 2.0 authorization_code with PKCE) |
 
 ### BrowserAuthProvider
 
@@ -328,6 +329,138 @@ const auth = new SmartBackendServicesAuthProvider({
 
 const client = new AidboxClient("https://fhir-server.address", auth);
 ```
+
+### SmartAppLaunchAuthProvider
+
+For provider-facing applications that authenticate users via [SMART App Launch](https://hl7.org/fhir/smart-app-launch/) (OAuth 2.0 authorization_code grant). Supports both **standalone launch** (user opens your app and selects a FHIR server) and **EHR launch** (the EHR opens your app via `?iss=...&launch=...`).
+
+The provider holds no session state of its own — your application stores the `SmartSession` (in a cookie session, Redis, `sessionStorage`, etc.) and supplies `getSession` / `setSession` callbacks. This works the same way in a browser SPA and in a server app.
+
+The flow has three stages, each backed by a top-level function:
+
+1. `authorize(config)` — at the launch URL, returns `{ redirectUrl, pending }`. Persist `pending` keyed by `pending.stateNonce`, then redirect the user-agent to `redirectUrl`.
+2. `exchangeCode({ url, pending })` — at the redirect URL, exchanges the `?code=...` for a `SmartSession`. Look up the previously stored `pending` using the `?state=...` query parameter.
+3. `new SmartAppLaunchAuthProvider(...)` — for subsequent FHIR requests. Adds `Authorization: Bearer ...`, refreshes proactively before expiry, retries once on 401.
+
+Features:
+- Discovery via `.well-known/smart-configuration`
+- PKCE with `S256` (configurable: `ifSupported` / `required` / `disabled`)
+- Standalone and EHR launch detected by inspecting the launch URL
+- Optional `issMatch` allow-list for the resolved `iss` (CSRF-style protection)
+- Confidential clients (`clientSecret`) supported via HTTP Basic on the token endpoint
+- Token refresh deduplication — concurrent FHIR requests share a single refresh
+
+#### Server-side example (Express-style pseudocode)
+
+```typescript
+import {
+  authorize,
+  exchangeCode,
+  AidboxClient,
+  SmartAppLaunchAuthProvider,
+  type PendingAuthorization,
+  type SmartSession,
+} from "@health-samurai/aidbox-client";
+
+// 1. Launch route — both standalone and EHR launches arrive here.
+//    For EHR launch the EHR appends `?iss=...&launch=...` to this URL.
+app.get("/launch", async (req, res) => {
+  const { redirectUrl, pending } = await authorize({
+    iss: "https://fhir.example.com", // fallback for standalone; query iss wins for EHR
+    clientId: process.env.SMART_CLIENT_ID,
+    scope: "launch openid fhirUser patient/*.read offline_access",
+    redirectUri: `${process.env.BASE_URL}/callback`,
+    launchUrl: req.url, // lets the helper extract iss/launch from query params
+    issMatch: /^https:\/\/(fhir|aidbox)\.example\.com$/,
+  });
+
+  req.session.pending = { [pending.stateNonce]: pending };
+  res.redirect(redirectUrl);
+});
+
+// 2. Callback route — exchange the code for a session.
+app.get("/callback", async (req, res) => {
+  const stateNonce = new URL(req.url, process.env.BASE_URL).searchParams.get("state");
+  const pending: PendingAuthorization = req.session.pending?.[stateNonce!];
+  if (!pending) return res.status(400).send("Unknown state");
+
+  const session = await exchangeCode({ url: req.url, pending });
+
+  req.session.smart = session;
+  delete req.session.pending;
+  res.redirect("/app");
+});
+
+// 3. Application route — use the provider for FHIR requests.
+app.get("/app", async (req, res) => {
+  const session: SmartSession | undefined = req.session.smart;
+  if (!session) return res.redirect("/launch");
+
+  const auth = new SmartAppLaunchAuthProvider({
+    baseUrl: session.serverUrl,
+    getSession: () => req.session.smart,
+    setSession: (s) => { req.session.smart = s; },
+  });
+
+  const client = new AidboxClient(session.serverUrl, auth);
+  const result = await client.read({ type: "Patient", id: session.patient! });
+  res.json(result.value.resource);
+});
+```
+
+#### Browser SPA example
+
+The same three calls work in the browser — only the storage backend changes (here `sessionStorage`):
+
+```typescript
+import {
+  authorize,
+  exchangeCode,
+  AidboxClient,
+  SmartAppLaunchAuthProvider,
+  type SmartSession,
+} from "@health-samurai/aidbox-client";
+
+// On the launch page (e.g. /launch.html)
+const { redirectUrl, pending } = await authorize({
+  iss: new URL(location.href).searchParams.get("iss") ?? "https://fhir.example.com",
+  launchUrl: location.href,
+  clientId: "my-spa",
+  scope: "launch openid fhirUser patient/*.read",
+  redirectUri: `${location.origin}/callback.html`,
+});
+sessionStorage.setItem(`smart:pending:${pending.stateNonce}`, JSON.stringify(pending));
+location.href = redirectUrl;
+
+// On the callback page (e.g. /callback.html)
+const stateNonce = new URL(location.href).searchParams.get("state")!;
+const pending = JSON.parse(sessionStorage.getItem(`smart:pending:${stateNonce}`)!);
+const session = await exchangeCode({ url: location.href, pending });
+sessionStorage.setItem("smart:session", JSON.stringify(session));
+sessionStorage.removeItem(`smart:pending:${stateNonce}`);
+location.href = "/app.html";
+
+// On any application page
+const auth = new SmartAppLaunchAuthProvider({
+  baseUrl: JSON.parse(sessionStorage.getItem("smart:session")!).serverUrl,
+  getSession: () => JSON.parse(sessionStorage.getItem("smart:session")!) as SmartSession,
+  setSession: (s) => sessionStorage.setItem("smart:session", JSON.stringify(s)),
+});
+const client = new AidboxClient(auth.baseUrl, auth);
+```
+
+#### Manual session management
+
+`authorize`, `exchangeCode`, `refreshSession`, and `revokeSession` are exported as standalone functions and can be used without `SmartAppLaunchAuthProvider` if you want to manage tokens manually:
+
+```typescript
+import { refreshSession, revokeSession } from "@health-samurai/aidbox-client";
+
+const refreshed = await refreshSession(session);  // returns a new SmartSession
+await revokeSession(session);                     // best-effort revocation at the auth server
+```
+
+> **Security note:** when scope includes `openid`, the token response carries an `id_token` JWT. This library does **not** validate the JWT signature, `iss`, `aud`, or `exp` — it stores the raw token in `session.idToken`. If you use `session.fhirUser` (or any id_token claim) for authorization decisions, validate the JWT yourself first.
 
 ### Custom Auth Provider
 

--- a/packages/aidbox-client/README.md
+++ b/packages/aidbox-client/README.md
@@ -336,6 +336,8 @@ For provider-facing applications that authenticate users via [SMART App Launch](
 
 The provider holds no session state of its own — your application stores the `SmartSession` (in a cookie session, Redis, `sessionStorage`, etc.) and supplies `getSession` / `setSession` callbacks. This works the same way in a browser SPA and in a server app.
 
+`exchangeCode()` stores token endpoint data in the session. When Aidbox includes `userinfo` in the token response, it is available as `session.userinfo`.
+
 The flow has three stages, each backed by a top-level function:
 
 1. `authorize(config)` — at the launch URL, returns `{ redirectUrl, pending }`. Persist `pending` keyed by `pending.stateNonce`, then redirect the user-agent to `redirectUrl`.
@@ -460,7 +462,7 @@ const refreshed = await refreshSession(session);  // returns a new SmartSession
 await revokeSession(session);                     // best-effort revocation at the auth server
 ```
 
-> **Security note:** when scope includes `openid`, the token response carries an `id_token` JWT. This library does **not** validate the JWT signature, `iss`, `aud`, or `exp` — it stores the raw token in `session.idToken`. If you use `session.fhirUser` (or any id_token claim) for authorization decisions, validate the JWT yourself first.
+> **Security note:** when scope includes `openid`, the token response carries an `id_token` JWT. This library does **not** validate the JWT signature, `iss`, `aud`, or `exp` — it stores the raw token in `session.idToken`. If you use id_token claims for authorization decisions, validate the JWT yourself first.
 
 ### Custom Auth Provider
 

--- a/packages/aidbox-client/src/index.ts
+++ b/packages/aidbox-client/src/index.ts
@@ -4,6 +4,7 @@ export type * from "./fhir-types/hl7-fhir-r4-core";
 export * from "./fhir-types/hl7-fhir-r4-core";
 export type * from "./result";
 export * from "./result";
+export * from "./smart-app-launch";
 export * from "./smart-backend-services";
 export type * from "./types";
 export * from "./types";

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -252,7 +252,7 @@ export async function authorize(
 	);
 
 	let scope = config.scope;
-	if (launch && !/\blaunch\b/.test(scope)) {
+	if (launch && !scope.split(/\s+/).includes("launch")) {
 		scope = `${scope} launch`.trim();
 	}
 

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -51,7 +51,10 @@ export type SmartTokenResponse<TUser = UserInfo> = {
 export type SmartRefreshTokenResponse = Required<
 	Pick<SmartTokenResponse, "access_token">
 > &
-	Pick<SmartTokenResponse, "expires_in" | "scope" | "patient" | "refresh_token"> & {
+	Pick<
+		SmartTokenResponse,
+		"expires_in" | "scope" | "patient" | "refresh_token"
+	> & {
 		token_type: "Bearer";
 	};
 
@@ -60,13 +63,14 @@ export type SmartRefreshTokenResponse = Required<
  *
  * Hosts persist this object in their session store (cookie session, Redis, etc.).
  * `accessToken` is always present; `expiresAt` is an absolute Unix timestamp in milliseconds, computed locally on receipt.
+ * Confidential client secrets are intentionally not stored here — supply them separately when refreshing or revoking.
  */
 export type SmartSession<TUser = UserInfo> = {
 	serverUrl: string;
 	clientId: string;
 	tokenUri: string;
 	revocationUri?: string | undefined;
-	clientSecret?: string | undefined;
+	usesClientSecret?: true | undefined;
 	accessToken: string;
 	refreshToken?: string | undefined;
 	expiresAt?: number | undefined;
@@ -82,11 +86,12 @@ export type SmartSession<TUser = UserInfo> = {
  *
  * Hosts persist this object briefly (typically in a server-side session, keyed by `stateNonce`) between the authorize redirect and the callback.
  * Lifetime is seconds-to-minutes; once `exchangeCode` succeeds it can be discarded.
+ * Confidential client secrets are intentionally not stored here — only the `usesClientSecret` flag is persisted.
  */
 export type PendingAuthorization = {
 	serverUrl: string;
 	clientId: string;
-	clientSecret?: string | undefined;
+	usesClientSecret?: true | undefined;
 	redirectUri: string;
 	scope: string;
 	authorizationServerIssuer?: string | undefined;
@@ -115,8 +120,8 @@ export type AuthorizeConfig = {
 	scope: string;
 	/** Absolute redirect URI registered with the authorization server. */
 	redirectUri: string;
-	/** Confidential client secret (server-side only). When set, token requests use HTTP Basic client auth. */
-	clientSecret?: string;
+	/** Confidential client secret (server-side only). Not persisted in `pending` or `session`; pass it again to token refresh/revocation helpers. */
+	clientSecret?: string | undefined;
 	/**
 	 * PKCE behavior.
 	 *
@@ -295,7 +300,7 @@ export async function authorize(
 	const pending: PendingAuthorization = {
 		serverUrl: iss,
 		clientId: config.clientId,
-		clientSecret: config.clientSecret,
+		usesClientSecret: config.clientSecret ? true : undefined,
 		redirectUri: config.redirectUri,
 		scope,
 		authorizationServerIssuer: smartConfig.issuer,
@@ -336,10 +341,27 @@ const buildBasicAuth = (clientId: string, clientSecret: string): string => {
 	return `Basic ${base64}`;
 };
 
+type ClientSecretRequirement = {
+	usesClientSecret?: true | undefined;
+};
+
+const resolveClientSecret = (
+	value: ClientSecretRequirement,
+	usage: string,
+	providedClientSecret?: string,
+): string | undefined => {
+	if (value.usesClientSecret && !providedClientSecret) {
+		throw new Error(
+			`${usage} requires clientSecret when usesClientSecret is true`,
+		);
+	}
+	return providedClientSecret;
+};
+
 const sessionFromTokenResponse = <TUser = UserInfo>(
 	pending: Pick<
 		PendingAuthorization,
-		"serverUrl" | "clientId" | "clientSecret" | "tokenUri" | "revocationUri"
+		"serverUrl" | "clientId" | "usesClientSecret" | "tokenUri" | "revocationUri"
 	>,
 	token: SmartTokenResponse<TUser>,
 ): SmartSession<TUser> => {
@@ -350,7 +372,7 @@ const sessionFromTokenResponse = <TUser = UserInfo>(
 	return {
 		serverUrl: pending.serverUrl,
 		clientId: pending.clientId,
-		clientSecret: pending.clientSecret,
+		usesClientSecret: pending.usesClientSecret,
 		tokenUri: pending.tokenUri,
 		revocationUri: pending.revocationUri,
 		accessToken: token.access_token,
@@ -370,6 +392,8 @@ export type ExchangeCodeParams = {
 	url: string | URL;
 	/** Pending authorization previously persisted by the host, looked up via the callback `state` query parameter. */
 	pending: PendingAuthorization;
+	/** Confidential client secret (server-side only). Required when `pending.usesClientSecret` is true. */
+	clientSecret?: string | undefined;
 };
 
 /**
@@ -414,10 +438,16 @@ export async function exchangeCode<TUser = UserInfo>(
 		accept: "application/json",
 	};
 
-	if (params.pending.clientSecret) {
+	const clientSecret = resolveClientSecret(
+		params.pending,
+		"exchangeCode()",
+		params.clientSecret,
+	);
+
+	if (clientSecret) {
 		headers.authorization = buildBasicAuth(
 			params.pending.clientId,
-			params.pending.clientSecret,
+			clientSecret,
 		);
 	} else {
 		body.set("client_id", params.pending.clientId);
@@ -437,7 +467,16 @@ export async function exchangeCode<TUser = UserInfo>(
 	}
 
 	const token = (await response.json()) as SmartTokenResponse<TUser>;
-	return sessionFromTokenResponse(params.pending, token);
+	return sessionFromTokenResponse(
+		{
+			serverUrl: params.pending.serverUrl,
+			clientId: params.pending.clientId,
+			usesClientSecret: params.pending.usesClientSecret,
+			tokenUri: params.pending.tokenUri,
+			revocationUri: params.pending.revocationUri,
+		},
+		token,
+	);
 }
 
 /**
@@ -449,6 +488,10 @@ export async function exchangeCode<TUser = UserInfo>(
  */
 export async function refreshSession<TUser = UserInfo>(
 	session: SmartSession<TUser>,
+	options?: {
+		/** Confidential client secret (server-side only). Required when `session.usesClientSecret` is true. */
+		clientSecret?: string | undefined;
+	},
 ): Promise<SmartSession<TUser>> {
 	if (!session.refreshToken) {
 		throw new Error("Cannot refresh — no refreshToken in session");
@@ -464,11 +507,13 @@ export async function refreshSession<TUser = UserInfo>(
 		accept: "application/json",
 	};
 
-	if (session.clientSecret) {
-		headers.authorization = buildBasicAuth(
-			session.clientId,
-			session.clientSecret,
-		);
+	const clientSecret = resolveClientSecret(
+		session,
+		"refreshSession()",
+		options?.clientSecret,
+	);
+	if (clientSecret) {
+		headers.authorization = buildBasicAuth(session.clientId, clientSecret);
 	} else {
 		body.set("client_id", session.clientId);
 	}
@@ -492,8 +537,8 @@ export async function refreshSession<TUser = UserInfo>(
 			? Date.now() + token.expires_in * 1000
 			: undefined;
 	const scope = token.scope ?? session.scope;
-  const patient = token.patient ?? session.patient;
-  const refreshToken = token.refresh_token ?? session.refreshToken;
+	const patient = token.patient ?? session.patient;
+	const refreshToken = token.refresh_token ?? session.refreshToken;
 	return {
 		...session,
 		accessToken: token.access_token,
@@ -512,6 +557,10 @@ export async function refreshSession<TUser = UserInfo>(
  */
 export async function revokeSession<TUser = UserInfo>(
 	session: SmartSession<TUser>,
+	options?: {
+		/** Confidential client secret (server-side only). Required when `session.usesClientSecret` is true. */
+		clientSecret?: string | undefined;
+	},
 ): Promise<void> {
 	if (!session.revocationUri) return;
 
@@ -521,11 +570,13 @@ export async function revokeSession<TUser = UserInfo>(
 	const headers: Record<string, string> = {
 		"content-type": "application/x-www-form-urlencoded",
 	};
-	if (session.clientSecret) {
-		headers.authorization = buildBasicAuth(
-			session.clientId,
-			session.clientSecret,
-		);
+	const clientSecret = resolveClientSecret(
+		session,
+		"revokeSession()",
+		options?.clientSecret,
+	);
+	if (clientSecret) {
+		headers.authorization = buildBasicAuth(session.clientId, clientSecret);
 	} else {
 		body.set("client_id", session.clientId);
 	}
@@ -554,6 +605,10 @@ export type SmartAppLaunchAuthProviderConfig<TUser = UserInfo> = {
 	getSession: () => SmartSession<TUser> | Promise<SmartSession<TUser>>;
 	/** Called whenever the provider obtains a new session (after refresh). The host must persist it. */
 	setSession: (session: SmartSession<TUser>) => void | Promise<void>;
+	/** Resolves the confidential client secret server-side. Required when sessions use `usesClientSecret`. */
+	getClientSecret?: (
+		session: SmartSession<TUser>,
+	) => string | undefined | Promise<string | undefined>;
 	/** Refresh the token this many seconds before expiry (default: 30). */
 	tokenExpirationBuffer?: number;
 };
@@ -571,6 +626,11 @@ export class SmartAppLaunchAuthProvider<TUser = UserInfo>
 
 	#getSession: () => SmartSession<TUser> | Promise<SmartSession<TUser>>;
 	#setSession: (session: SmartSession<TUser>) => void | Promise<void>;
+	#getClientSecret:
+		| ((
+				session: SmartSession<TUser>,
+		  ) => string | undefined | Promise<string | undefined>)
+		| undefined;
 	#expirationBuffer: number;
 	#pendingRefresh: Promise<SmartSession<TUser>> | null = null;
 
@@ -578,6 +638,7 @@ export class SmartAppLaunchAuthProvider<TUser = UserInfo>
 		this.baseUrl = config.baseUrl;
 		this.#getSession = config.getSession;
 		this.#setSession = config.setSession;
+		this.#getClientSecret = config.getClientSecret;
 		this.#expirationBuffer = config.tokenExpirationBuffer ?? 30;
 	}
 
@@ -589,7 +650,8 @@ export class SmartAppLaunchAuthProvider<TUser = UserInfo>
 	async #refresh(session: SmartSession<TUser>): Promise<SmartSession<TUser>> {
 		if (this.#pendingRefresh) return this.#pendingRefresh;
 		this.#pendingRefresh = (async () => {
-			const next = await refreshSession(session);
+			const clientSecret = await this.#getClientSecret?.(session);
+			const next = await refreshSession(session, { clientSecret });
 			await this.#setSession(next);
 			return next;
 		})();
@@ -619,7 +681,8 @@ export class SmartAppLaunchAuthProvider<TUser = UserInfo>
 	 */
 	async revokeSession(): Promise<void> {
 		const session = await this.#getSession();
-		await revokeSession(session);
+		const clientSecret = await this.#getClientSecret?.(session);
+		await revokeSession(session, { clientSecret });
 	}
 
 	async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -459,7 +459,10 @@ export async function refreshSession(
 	const next = sessionFromTokenResponse(session, token);
 	if (!next.refreshToken && session.refreshToken) {
 		next.refreshToken = session.refreshToken;
-		next.tokenResponse = { ...next.tokenResponse, refresh_token: session.refreshToken };
+		next.tokenResponse = {
+			...next.tokenResponse,
+			refresh_token: session.refreshToken,
+		};
 	}
 	return next;
 }
@@ -578,10 +581,7 @@ export class SmartAppLaunchAuthProvider implements AuthProvider {
 		await revokeSession(session);
 	}
 
-	async fetch(
-		input: RequestInfo | URL,
-		init?: RequestInit,
-	): Promise<Response> {
+	async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
 		validateBaseUrl(input, this.baseUrl);
 
 		let session = await this.#getSession();

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -1,0 +1,620 @@
+import type { AuthProvider } from "./types";
+import { mergeHeaders, validateBaseUrl } from "./utils";
+
+/// IMPORTANT:
+///
+/// PLEASE, use one sentence per line approach in the docstrings.
+/// Don't use hard-wrapping, it makes git-diff a painfull experience.
+
+/**
+ * SMART configuration document fields read by this implementation.
+ *
+ * @see https://hl7.org/fhir/smart-app-launch/conformance.html#smart-configuration
+ */
+export type SmartConfiguration = {
+	authorization_endpoint: string;
+	token_endpoint: string;
+	revocation_endpoint?: string | undefined;
+	code_challenge_methods_supported?: string[] | undefined;
+	scopes_supported?: string[] | undefined;
+	capabilities?: string[] | undefined;
+	[key: string]: unknown;
+};
+
+/**
+ * Token bundle returned by `exchangeCode` and `refreshSession`.
+ *
+ * SMART App Launch token responses extend OAuth 2.0 with launch context (`patient`, `encounter`, `fhirUser`, `id_token`).
+ *
+ * `id_token` (when scope includes `openid`) is **not** validated by this library — callers that rely on `fhirUser` for authorization decisions must verify the JWT signature, `iss`, `aud`, and `exp` themselves.
+ */
+export type SmartTokenResponse = {
+	access_token: string;
+	token_type?: string;
+	refresh_token?: string;
+	expires_in?: number;
+	scope?: string;
+	id_token?: string;
+	patient?: string;
+	encounter?: string;
+	fhirUser?: string;
+	[key: string]: unknown;
+};
+
+/**
+ * The session established after a successful SMART App Launch.
+ *
+ * Hosts persist this object in their session store (cookie session, Redis, etc.).
+ * `accessToken` is always present; `expiresAt` is an absolute Unix timestamp in milliseconds, computed locally on receipt.
+ */
+export type SmartSession = {
+	serverUrl: string;
+	clientId: string;
+	tokenUri: string;
+	revocationUri?: string | undefined;
+	clientSecret?: string | undefined;
+	accessToken: string;
+	refreshToken?: string | undefined;
+	expiresAt?: number | undefined;
+	scope?: string | undefined;
+	patient?: string | undefined;
+	encounter?: string | undefined;
+	fhirUser?: string | undefined;
+	idToken?: string | undefined;
+	tokenResponse: SmartTokenResponse;
+};
+
+/**
+ * In-flight authorization request — created by `authorize`, consumed by `exchangeCode`.
+ *
+ * Hosts persist this object briefly (typically in a server-side session, keyed by `stateNonce`) between the authorize redirect and the callback.
+ * Lifetime is seconds-to-minutes; once `exchangeCode` succeeds it can be discarded.
+ */
+export type PendingAuthorization = {
+	serverUrl: string;
+	clientId: string;
+	clientSecret?: string | undefined;
+	redirectUri: string;
+	scope: string;
+	authorizeUri: string;
+	tokenUri: string;
+	revocationUri?: string | undefined;
+	stateNonce: string;
+	codeVerifier?: string | undefined;
+	codeChallengeMethod?: "S256" | undefined;
+};
+
+/**
+ * Configuration accepted by `authorize`.
+ *
+ * Standalone vs EHR launch is determined by inspecting `launchUrl`:
+ * if it carries `iss` and `launch` query parameters the request is treated as an EHR launch and those values override `iss`/`launch` from config.
+ */
+export type AuthorizeConfig = {
+	/** FHIR server base URL. Required for standalone launch; ignored if present in `launchUrl` query. */
+	iss?: string;
+	/** EHR launch parameter. Usually comes from `launchUrl` query, not config. */
+	launch?: string;
+	/** OAuth 2.0 client identifier. */
+	clientId: string;
+	/** Space-separated scope string. `launch` scope is auto-appended for EHR launches if missing. */
+	scope: string;
+	/** Absolute redirect URI registered with the authorization server. */
+	redirectUri: string;
+	/** Confidential client secret (server-side only). When set, token requests use HTTP Basic client auth. */
+	clientSecret?: string;
+	/**
+	 * PKCE behavior.
+	 *
+	 * `ifSupported` (default) — enable PKCE iff server advertises `S256` in `code_challenge_methods_supported`.
+	 * `required` — throw if `S256` is not advertised.
+	 * `disabled` — never use PKCE.
+	 */
+	pkceMode?: "ifSupported" | "required" | "disabled";
+	/** Optional allow-list for the resolved `iss`, guarding against arbitrary-iss CSRF. */
+	issMatch?: string | RegExp | ((iss: string) => boolean);
+	/** Full URL of the current launch request — used to extract `iss` and `launch` from query parameters. */
+	launchUrl?: string | URL;
+	/** Pass-through `RequestInit` for the discovery request. */
+	wellKnownRequestOptions?: RequestInit;
+};
+
+/** Result of `authorize`. */
+export type AuthorizeResult = {
+	/** URL the host should redirect the user-agent to. */
+	redirectUrl: string;
+	/** Pending authorization to persist before redirecting; looked up by `stateNonce` on callback. */
+	pending: PendingAuthorization;
+};
+
+const SMART_CONFIG_PATH = "/.well-known/smart-configuration";
+
+const checkIssMatch = (
+	iss: string,
+	matcher: AuthorizeConfig["issMatch"],
+): void => {
+	if (matcher === undefined) return;
+	let ok = false;
+	if (typeof matcher === "string") ok = iss === matcher;
+	else if (matcher instanceof RegExp) ok = matcher.test(iss);
+	else if (typeof matcher === "function") ok = matcher(iss);
+	if (!ok) {
+		throw new Error(`SMART issMatch rejected iss: ${iss}`);
+	}
+};
+
+const base64url = (bytes: Uint8Array): string => {
+	let str = "";
+	for (const b of bytes) str += String.fromCharCode(b);
+	return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+const generateRandomString = (bytes = 32): string => {
+	const buf = new Uint8Array(bytes);
+	crypto.getRandomValues(buf);
+	return base64url(buf);
+};
+
+const calculatePkceChallenge = async (verifier: string): Promise<string> => {
+	const data = new TextEncoder().encode(verifier);
+	const digest = await crypto.subtle.digest("SHA-256", data);
+	return base64url(new Uint8Array(digest));
+};
+
+/**
+ * Fetch the SMART configuration document from `{iss}/.well-known/smart-configuration`.
+ *
+ * Throws if the document is missing or lacks required endpoints.
+ */
+export async function fetchSmartConfiguration(
+	iss: string,
+	requestInit?: RequestInit,
+): Promise<SmartConfiguration> {
+	const base = iss.endsWith("/") ? iss.slice(0, -1) : iss;
+	const url = `${base}${SMART_CONFIG_PATH}`;
+	const response = await fetch(url, {
+		...requestInit,
+		headers: {
+			accept: "application/json",
+			...(requestInit?.headers as Record<string, string> | undefined),
+		},
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch SMART configuration from ${url}: ${response.status} ${response.statusText}`,
+		);
+	}
+	const config = (await response.json()) as SmartConfiguration;
+	if (!config.authorization_endpoint || !config.token_endpoint) {
+		throw new Error(
+			`SMART configuration at ${url} is missing required endpoints`,
+		);
+	}
+	return config;
+}
+
+const resolvePkce = (
+	mode: AuthorizeConfig["pkceMode"],
+	supported: string[] | undefined,
+): boolean => {
+	const has256 = supported?.includes("S256") ?? false;
+	switch (mode ?? "ifSupported") {
+		case "disabled":
+			return false;
+		case "required":
+			if (!has256) {
+				throw new Error(
+					"pkceMode=required but server does not advertise S256 in code_challenge_methods_supported",
+				);
+			}
+			return true;
+		case "ifSupported":
+			return has256;
+	}
+};
+
+/**
+ * Build an authorization redirect URL and prepare the pending authorization.
+ *
+ * The host must persist `result.pending` (typically keyed by `result.pending.stateNonce`) before redirecting.
+ * On callback, the `state` query parameter equals `stateNonce`, allowing the host to look up the pending authorization and pass it to `exchangeCode`.
+ */
+export async function authorize(
+	config: AuthorizeConfig,
+): Promise<AuthorizeResult> {
+	let iss = config.iss;
+	let launch = config.launch;
+
+	if (config.launchUrl !== undefined) {
+		const url = new URL(config.launchUrl);
+		const queryIss = url.searchParams.get("iss");
+		const queryLaunch = url.searchParams.get("launch");
+		if (queryIss) iss = queryIss;
+		if (queryLaunch) launch = queryLaunch;
+	}
+
+	if (!iss) {
+		throw new Error(
+			"authorize() requires `iss` (either via config or as a query param in `launchUrl`)",
+		);
+	}
+
+	checkIssMatch(iss, config.issMatch);
+
+	const smartConfig = await fetchSmartConfiguration(
+		iss,
+		config.wellKnownRequestOptions,
+	);
+
+	const usePkce = resolvePkce(
+		config.pkceMode,
+		smartConfig.code_challenge_methods_supported,
+	);
+
+	let scope = config.scope;
+	if (launch && !/\blaunch\b/.test(scope)) {
+		scope = `${scope} launch`.trim();
+	}
+
+	const stateNonce = generateRandomString(16);
+
+	let codeVerifier: string | undefined;
+	let codeChallenge: string | undefined;
+	if (usePkce) {
+		codeVerifier = generateRandomString(32);
+		codeChallenge = await calculatePkceChallenge(codeVerifier);
+	}
+
+	const authorizeUrl = new URL(smartConfig.authorization_endpoint);
+	authorizeUrl.searchParams.set("response_type", "code");
+	authorizeUrl.searchParams.set("client_id", config.clientId);
+	authorizeUrl.searchParams.set("redirect_uri", config.redirectUri);
+	authorizeUrl.searchParams.set("scope", scope);
+	authorizeUrl.searchParams.set("state", stateNonce);
+	authorizeUrl.searchParams.set("aud", iss);
+	if (launch) authorizeUrl.searchParams.set("launch", launch);
+	if (codeChallenge) {
+		authorizeUrl.searchParams.set("code_challenge", codeChallenge);
+		authorizeUrl.searchParams.set("code_challenge_method", "S256");
+	}
+
+	const pending: PendingAuthorization = {
+		serverUrl: iss,
+		clientId: config.clientId,
+		clientSecret: config.clientSecret,
+		redirectUri: config.redirectUri,
+		scope,
+		authorizeUri: smartConfig.authorization_endpoint,
+		tokenUri: smartConfig.token_endpoint,
+		revocationUri: smartConfig.revocation_endpoint,
+		stateNonce,
+		codeVerifier,
+		codeChallengeMethod: usePkce ? "S256" : undefined,
+	};
+
+	return {
+		redirectUrl: authorizeUrl.toString(),
+		pending,
+	};
+}
+
+const buildBasicAuth = (clientId: string, clientSecret: string): string => {
+	const creds = `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`;
+	const utf8 = new TextEncoder().encode(creds);
+	const base64 = btoa(String.fromCharCode(...utf8));
+	return `Basic ${base64}`;
+};
+
+const sessionFromTokenResponse = (
+	pending: Pick<
+		PendingAuthorization,
+		"serverUrl" | "clientId" | "clientSecret" | "tokenUri" | "revocationUri"
+	>,
+	token: SmartTokenResponse,
+): SmartSession => {
+	const expiresAt =
+		token.expires_in !== undefined
+			? Date.now() + token.expires_in * 1000
+			: undefined;
+	return {
+		serverUrl: pending.serverUrl,
+		clientId: pending.clientId,
+		clientSecret: pending.clientSecret,
+		tokenUri: pending.tokenUri,
+		revocationUri: pending.revocationUri,
+		accessToken: token.access_token,
+		refreshToken: token.refresh_token,
+		expiresAt,
+		scope: token.scope,
+		patient: token.patient,
+		encounter: token.encounter,
+		fhirUser: token.fhirUser,
+		idToken: token.id_token,
+		tokenResponse: token,
+	};
+};
+
+/** Parameters for `exchangeCode`. */
+export type ExchangeCodeParams = {
+	/** Full callback URL with `?code=...&state=...` query parameters. */
+	url: string | URL;
+	/** Pending authorization previously persisted by the host, looked up via the callback `state` query parameter. */
+	pending: PendingAuthorization;
+};
+
+/**
+ * Exchange the authorization code from the callback URL for an established `SmartSession`.
+ *
+ * Validates the `state` query parameter against `pending.stateNonce`.
+ * Surfaces `error`/`error_description` from the callback URL as a thrown `Error`.
+ */
+export async function exchangeCode(
+	params: ExchangeCodeParams,
+): Promise<SmartSession> {
+	const url = new URL(params.url);
+
+	const oauthError = url.searchParams.get("error");
+	if (oauthError) {
+		const description = url.searchParams.get("error_description");
+		throw new Error(
+			`SMART authorization error: ${oauthError}${description ? ` — ${description}` : ""}`,
+		);
+	}
+
+	const code = url.searchParams.get("code");
+	const returnedState = url.searchParams.get("state");
+	if (!code) {
+		throw new Error("Callback URL is missing `code` query parameter");
+	}
+	if (!returnedState || returnedState !== params.pending.stateNonce) {
+		throw new Error("Callback `state` does not match pending authorization");
+	}
+
+	const body = new URLSearchParams();
+	body.set("grant_type", "authorization_code");
+	body.set("code", code);
+	body.set("redirect_uri", params.pending.redirectUri);
+	if (params.pending.codeVerifier) {
+		body.set("code_verifier", params.pending.codeVerifier);
+	}
+
+	const headers: Record<string, string> = {
+		"content-type": "application/x-www-form-urlencoded",
+		accept: "application/json",
+	};
+
+	if (params.pending.clientSecret) {
+		headers.authorization = buildBasicAuth(
+			params.pending.clientId,
+			params.pending.clientSecret,
+		);
+	} else {
+		body.set("client_id", params.pending.clientId);
+	}
+
+	const response = await fetch(params.pending.tokenUri, {
+		method: "POST",
+		headers,
+		body: body.toString(),
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`Token endpoint returned ${response.status}: ${text || response.statusText}`,
+		);
+	}
+
+	const token = (await response.json()) as SmartTokenResponse;
+	return sessionFromTokenResponse(params.pending, token);
+}
+
+/**
+ * Use the session's refresh token to obtain a fresh access token.
+ *
+ * Throws if the session has no `refreshToken`.
+ * Returns a new session — the original is not mutated.
+ * If the server omits `refresh_token` in the response, the previous one is preserved.
+ */
+export async function refreshSession(
+	session: SmartSession,
+): Promise<SmartSession> {
+	if (!session.refreshToken) {
+		throw new Error("Cannot refresh — no refreshToken in session");
+	}
+
+	const body = new URLSearchParams();
+	body.set("grant_type", "refresh_token");
+	body.set("refresh_token", session.refreshToken);
+	if (session.scope) body.set("scope", session.scope);
+
+	const headers: Record<string, string> = {
+		"content-type": "application/x-www-form-urlencoded",
+		accept: "application/json",
+	};
+
+	if (session.clientSecret) {
+		headers.authorization = buildBasicAuth(
+			session.clientId,
+			session.clientSecret,
+		);
+	} else {
+		body.set("client_id", session.clientId);
+	}
+
+	const response = await fetch(session.tokenUri, {
+		method: "POST",
+		headers,
+		body: body.toString(),
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`Token refresh failed (${response.status}): ${text || response.statusText}`,
+		);
+	}
+
+	const token = (await response.json()) as SmartTokenResponse;
+	const next = sessionFromTokenResponse(session, token);
+	if (!next.refreshToken && session.refreshToken) {
+		next.refreshToken = session.refreshToken;
+		next.tokenResponse = { ...next.tokenResponse, refresh_token: session.refreshToken };
+	}
+	return next;
+}
+
+/**
+ * Best-effort revocation of the session's tokens at the server's revocation endpoint.
+ *
+ * No-op if the session has no `revocationUri`.
+ * Errors are swallowed — revocation is best-effort.
+ */
+export async function revokeSession(session: SmartSession): Promise<void> {
+	if (!session.revocationUri) return;
+
+	const body = new URLSearchParams();
+	body.set("token", session.refreshToken ?? session.accessToken);
+
+	const headers: Record<string, string> = {
+		"content-type": "application/x-www-form-urlencoded",
+	};
+	if (session.clientSecret) {
+		headers.authorization = buildBasicAuth(
+			session.clientId,
+			session.clientSecret,
+		);
+	} else {
+		body.set("client_id", session.clientId);
+	}
+
+	try {
+		await fetch(session.revocationUri, {
+			method: "POST",
+			headers,
+			body: body.toString(),
+		});
+	} catch {
+		// Best-effort.
+	}
+}
+
+/**
+ * Configuration for `SmartAppLaunchAuthProvider`.
+ *
+ * The provider holds no session state of its own — it asks the host for the current session on every request via `getSession`, and reports refreshed sessions back via `setSession`.
+ * This makes the host's session store the single source of truth and avoids cache-coherence bugs across multiple provider instances or processes.
+ */
+export type SmartAppLaunchAuthProviderConfig = {
+	/** FHIR server base URL — used for `validateBaseUrl` and exposed as `provider.baseUrl`. */
+	baseUrl: string;
+	/** Called on every request to retrieve the current session. */
+	getSession: () => SmartSession | Promise<SmartSession>;
+	/** Called whenever the provider obtains a new session (after refresh). The host must persist it. */
+	setSession: (session: SmartSession) => void | Promise<void>;
+	/** Refresh the token this many seconds before expiry (default: 30). */
+	tokenExpirationBuffer?: number;
+};
+
+/**
+ * `AuthProvider` backed by a host-managed `SmartSession`.
+ *
+ * Adds `Authorization: Bearer ...` to outgoing requests, refreshes proactively before expiry, retries once on 401, and deduplicates concurrent refreshes.
+ * The provider never caches the session — the host's `getSession`/`setSession` callbacks are the single source of truth.
+ */
+export class SmartAppLaunchAuthProvider implements AuthProvider {
+	public baseUrl: string;
+
+	#getSession: () => SmartSession | Promise<SmartSession>;
+	#setSession: (session: SmartSession) => void | Promise<void>;
+	#expirationBuffer: number;
+	#pendingRefresh: Promise<SmartSession> | null = null;
+
+	constructor(config: SmartAppLaunchAuthProviderConfig) {
+		this.baseUrl = config.baseUrl;
+		this.#getSession = config.getSession;
+		this.#setSession = config.setSession;
+		this.#expirationBuffer = config.tokenExpirationBuffer ?? 30;
+	}
+
+	#isFresh(session: SmartSession): boolean {
+		if (session.expiresAt === undefined) return true;
+		return session.expiresAt > Date.now() + this.#expirationBuffer * 1000;
+	}
+
+	async #refresh(session: SmartSession): Promise<SmartSession> {
+		if (this.#pendingRefresh) return this.#pendingRefresh;
+		this.#pendingRefresh = (async () => {
+			const next = await refreshSession(session);
+			await this.#setSession(next);
+			return next;
+		})();
+		try {
+			return await this.#pendingRefresh;
+		} finally {
+			this.#pendingRefresh = null;
+		}
+	}
+
+	/**
+	 * Ensure the current session has a valid access token, refreshing if necessary.
+	 */
+	async establishSession(): Promise<void> {
+		const session = await this.#getSession();
+		if (this.#isFresh(session)) return;
+		if (!session.refreshToken) {
+			throw new Error(
+				"SmartAppLaunchAuthProvider: session is expired and has no refreshToken",
+			);
+		}
+		await this.#refresh(session);
+	}
+
+	/**
+	 * Best-effort revocation of the current session's tokens.
+	 */
+	async revokeSession(): Promise<void> {
+		const session = await this.#getSession();
+		await revokeSession(session);
+	}
+
+	async fetch(
+		input: RequestInfo | URL,
+		init?: RequestInit,
+	): Promise<Response> {
+		validateBaseUrl(input, this.baseUrl);
+
+		let session = await this.#getSession();
+		if (!this.#isFresh(session) && session.refreshToken) {
+			session = await this.#refresh(session);
+		}
+
+		const requestInit = init ?? {};
+		const baseHeaders = input instanceof Request ? input.headers : undefined;
+		const initHeaders = requestInit.headers
+			? new Headers(requestInit.headers)
+			: undefined;
+		const merged = mergeHeaders(baseHeaders, initHeaders);
+		merged.set("Authorization", `Bearer ${session.accessToken}`);
+		requestInit.headers = merged;
+
+		const clonedInput = input instanceof Request ? input.clone() : input;
+		let retryBody: BodyInit | null | undefined = requestInit.body;
+		if (requestInit.body instanceof ReadableStream) {
+			const [s1, s2] = requestInit.body.tee();
+			requestInit.body = s1;
+			retryBody = s2;
+		}
+
+		let response = await fetch(clonedInput, requestInit);
+
+		if (response.status === 401 && session.refreshToken) {
+			const refreshed = await this.#refresh(session);
+			merged.set("Authorization", `Bearer ${refreshed.accessToken}`);
+			if (retryBody !== undefined) requestInit.body = retryBody;
+			response = await fetch(input, requestInit);
+		}
+
+		return response;
+	}
+}

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -1,4 +1,4 @@
-import type { AuthProvider } from "./types";
+import type { AuthProvider, UserInfo } from "./types";
 import { mergeHeaders, validateBaseUrl } from "./utils";
 
 /// IMPORTANT:
@@ -25,11 +25,12 @@ export type SmartConfiguration = {
 /**
  * Token bundle returned by `exchangeCode`.
  *
- * SMART App Launch token responses extend OAuth 2.0 with launch context (`patient`, `encounter`, `fhirUser`, `id_token`).
+ * SMART App Launch token responses extend OAuth 2.0 with launch context (`patient`, `encounter`, `id_token`).
+ * Aidbox token responses may also include `userinfo`, containing the Aidbox `User` resource.
  *
- * `id_token` (when scope includes `openid`) is **not** validated by this library — callers that rely on `fhirUser` for authorization decisions must verify the JWT signature, `iss`, `aud`, and `exp` themselves.
+ * `id_token` (when scope includes `openid`) is **not** validated by this library — callers that rely on id_token claims for authorization decisions must verify the JWT signature, `iss`, `aud`, and `exp` themselves.
  */
-export type SmartTokenResponse = {
+export type SmartTokenResponse<TUser = UserInfo> = {
 	access_token: string;
 	token_type?: string;
 	refresh_token?: string;
@@ -38,7 +39,7 @@ export type SmartTokenResponse = {
 	id_token?: string;
 	patient?: string;
 	encounter?: string;
-	fhirUser?: string;
+	userinfo?: TUser;
 	[key: string]: unknown;
 };
 
@@ -60,7 +61,7 @@ export type SmartRefreshTokenResponse = Required<
  * Hosts persist this object in their session store (cookie session, Redis, etc.).
  * `accessToken` is always present; `expiresAt` is an absolute Unix timestamp in milliseconds, computed locally on receipt.
  */
-export type SmartSession = {
+export type SmartSession<TUser = UserInfo> = {
 	serverUrl: string;
 	clientId: string;
 	tokenUri: string;
@@ -72,8 +73,8 @@ export type SmartSession = {
 	scope?: string | undefined;
 	patient?: string | undefined;
 	encounter?: string | undefined;
-	fhirUser?: string | undefined;
 	idToken?: string | undefined;
+	userinfo?: TUser | undefined;
 };
 
 /**
@@ -335,13 +336,13 @@ const buildBasicAuth = (clientId: string, clientSecret: string): string => {
 	return `Basic ${base64}`;
 };
 
-const sessionFromTokenResponse = (
+const sessionFromTokenResponse = <TUser = UserInfo>(
 	pending: Pick<
 		PendingAuthorization,
 		"serverUrl" | "clientId" | "clientSecret" | "tokenUri" | "revocationUri"
 	>,
-	token: SmartTokenResponse,
-): SmartSession => {
+	token: SmartTokenResponse<TUser>,
+): SmartSession<TUser> => {
 	const expiresAt =
 		token.expires_in !== undefined
 			? Date.now() + token.expires_in * 1000
@@ -358,8 +359,8 @@ const sessionFromTokenResponse = (
 		scope: token.scope,
 		patient: token.patient,
 		encounter: token.encounter,
-		fhirUser: token.fhirUser,
 		idToken: token.id_token,
+		userinfo: token.userinfo,
 	};
 };
 
@@ -377,9 +378,9 @@ export type ExchangeCodeParams = {
  * Validates the `state` query parameter against `pending.stateNonce`.
  * Surfaces `error`/`error_description` from the callback URL as a thrown `Error`.
  */
-export async function exchangeCode(
+export async function exchangeCode<TUser = UserInfo>(
 	params: ExchangeCodeParams,
-): Promise<SmartSession> {
+): Promise<SmartSession<TUser>> {
 	const url = new URL(params.url);
 	const returnedState = url.searchParams.get("state");
 	if (!returnedState || returnedState !== params.pending.stateNonce) {
@@ -435,7 +436,7 @@ export async function exchangeCode(
 		);
 	}
 
-	const token = (await response.json()) as SmartTokenResponse;
+	const token = (await response.json()) as SmartTokenResponse<TUser>;
 	return sessionFromTokenResponse(params.pending, token);
 }
 
@@ -446,9 +447,9 @@ export async function exchangeCode(
  * Returns a new session — the original is not mutated.
  * If the server omits `refresh_token` in the response, the previous one is preserved.
  */
-export async function refreshSession(
-	session: SmartSession,
-): Promise<SmartSession> {
+export async function refreshSession<TUser = UserInfo>(
+	session: SmartSession<TUser>,
+): Promise<SmartSession<TUser>> {
 	if (!session.refreshToken) {
 		throw new Error("Cannot refresh — no refreshToken in session");
 	}
@@ -509,7 +510,9 @@ export async function refreshSession(
  * No-op if the session has no `revocationUri`.
  * Errors are swallowed — revocation is best-effort.
  */
-export async function revokeSession(session: SmartSession): Promise<void> {
+export async function revokeSession<TUser = UserInfo>(
+	session: SmartSession<TUser>,
+): Promise<void> {
 	if (!session.revocationUri) return;
 
 	const body = new URLSearchParams();
@@ -544,13 +547,13 @@ export async function revokeSession(session: SmartSession): Promise<void> {
  * The provider holds no session state of its own — it asks the host for the current session on every request via `getSession`, and reports refreshed sessions back via `setSession`.
  * This makes the host's session store the single source of truth and avoids cache-coherence bugs across multiple provider instances or processes.
  */
-export type SmartAppLaunchAuthProviderConfig = {
+export type SmartAppLaunchAuthProviderConfig<TUser = UserInfo> = {
 	/** FHIR server base URL — used for `validateBaseUrl` and exposed as `provider.baseUrl`. */
 	baseUrl: string;
 	/** Called on every request to retrieve the current session. */
-	getSession: () => SmartSession | Promise<SmartSession>;
+	getSession: () => SmartSession<TUser> | Promise<SmartSession<TUser>>;
 	/** Called whenever the provider obtains a new session (after refresh). The host must persist it. */
-	setSession: (session: SmartSession) => void | Promise<void>;
+	setSession: (session: SmartSession<TUser>) => void | Promise<void>;
 	/** Refresh the token this many seconds before expiry (default: 30). */
 	tokenExpirationBuffer?: number;
 };
@@ -561,27 +564,29 @@ export type SmartAppLaunchAuthProviderConfig = {
  * Adds `Authorization: Bearer ...` to outgoing requests, refreshes proactively before expiry, retries once on 401, and deduplicates concurrent refreshes.
  * The provider never caches the session — the host's `getSession`/`setSession` callbacks are the single source of truth.
  */
-export class SmartAppLaunchAuthProvider implements AuthProvider {
+export class SmartAppLaunchAuthProvider<TUser = UserInfo>
+	implements AuthProvider
+{
 	public baseUrl: string;
 
-	#getSession: () => SmartSession | Promise<SmartSession>;
-	#setSession: (session: SmartSession) => void | Promise<void>;
+	#getSession: () => SmartSession<TUser> | Promise<SmartSession<TUser>>;
+	#setSession: (session: SmartSession<TUser>) => void | Promise<void>;
 	#expirationBuffer: number;
-	#pendingRefresh: Promise<SmartSession> | null = null;
+	#pendingRefresh: Promise<SmartSession<TUser>> | null = null;
 
-	constructor(config: SmartAppLaunchAuthProviderConfig) {
+	constructor(config: SmartAppLaunchAuthProviderConfig<TUser>) {
 		this.baseUrl = config.baseUrl;
 		this.#getSession = config.getSession;
 		this.#setSession = config.setSession;
 		this.#expirationBuffer = config.tokenExpirationBuffer ?? 30;
 	}
 
-	#isFresh(session: SmartSession): boolean {
+	#isFresh(session: SmartSession<TUser>): boolean {
 		if (session.expiresAt === undefined) return true;
 		return session.expiresAt > Date.now() + this.#expirationBuffer * 1000;
 	}
 
-	async #refresh(session: SmartSession): Promise<SmartSession> {
+	async #refresh(session: SmartSession<TUser>): Promise<SmartSession<TUser>> {
 		if (this.#pendingRefresh) return this.#pendingRefresh;
 		this.#pendingRefresh = (async () => {
 			const next = await refreshSession(session);

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -12,6 +12,7 @@ import { mergeHeaders, validateBaseUrl } from "./utils";
  * @see https://hl7.org/fhir/smart-app-launch/conformance.html#smart-configuration
  */
 export type SmartConfiguration = {
+	issuer?: string | undefined;
 	authorization_endpoint: string;
 	token_endpoint: string;
 	revocation_endpoint?: string | undefined;
@@ -76,6 +77,7 @@ export type PendingAuthorization = {
 	clientSecret?: string | undefined;
 	redirectUri: string;
 	scope: string;
+	authorizationServerIssuer?: string | undefined;
 	authorizeUri: string;
 	tokenUri: string;
 	revocationUri?: string | undefined;
@@ -284,6 +286,7 @@ export async function authorize(
 		clientSecret: config.clientSecret,
 		redirectUri: config.redirectUri,
 		scope,
+		authorizationServerIssuer: smartConfig.issuer,
 		authorizeUri: smartConfig.authorization_endpoint,
 		tokenUri: smartConfig.token_endpoint,
 		revocationUri: smartConfig.revocation_endpoint,
@@ -297,6 +300,22 @@ export async function authorize(
 		pending,
 	};
 }
+
+const validateAuthorizationResponseIssuer = (
+	url: URL,
+	pending: Pick<PendingAuthorization, "authorizationServerIssuer">,
+): void => {
+	const responseIss = url.searchParams.get("iss");
+	if (!responseIss) return;
+	if (
+		pending.authorizationServerIssuer &&
+		responseIss !== pending.authorizationServerIssuer
+	) {
+		throw new Error(
+			`Callback \`iss\` does not match expected authorization server issuer: ${responseIss}`,
+		);
+	}
+};
 
 const buildBasicAuth = (clientId: string, clientSecret: string): string => {
 	const creds = `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`;
@@ -352,6 +371,11 @@ export async function exchangeCode(
 	params: ExchangeCodeParams,
 ): Promise<SmartSession> {
 	const url = new URL(params.url);
+	const returnedState = url.searchParams.get("state");
+	if (!returnedState || returnedState !== params.pending.stateNonce) {
+		throw new Error("Callback `state` does not match pending authorization");
+	}
+	validateAuthorizationResponseIssuer(url, params.pending);
 
 	const oauthError = url.searchParams.get("error");
 	if (oauthError) {
@@ -362,12 +386,8 @@ export async function exchangeCode(
 	}
 
 	const code = url.searchParams.get("code");
-	const returnedState = url.searchParams.get("state");
 	if (!code) {
 		throw new Error("Callback URL is missing `code` query parameter");
-	}
-	if (!returnedState || returnedState !== params.pending.stateNonce) {
-		throw new Error("Callback `state` does not match pending authorization");
 	}
 
 	const body = new URLSearchParams();

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -23,7 +23,7 @@ export type SmartConfiguration = {
 };
 
 /**
- * Token bundle returned by `exchangeCode` and `refreshSession`.
+ * Token bundle returned by `exchangeCode`.
  *
  * SMART App Launch token responses extend OAuth 2.0 with launch context (`patient`, `encounter`, `fhirUser`, `id_token`).
  *
@@ -41,6 +41,18 @@ export type SmartTokenResponse = {
 	fhirUser?: string;
 	[key: string]: unknown;
 };
+
+/**
+ * Token bundle returned by `refreshSession`.
+ *
+ * This implementation expects the core SMART/OAuth refresh fields.
+ */
+export type SmartRefreshTokenResponse = Required<
+	Pick<SmartTokenResponse, "access_token">
+> &
+	Pick<SmartTokenResponse, "expires_in" | "scope" | "patient"> & {
+		token_type: "Bearer";
+	};
 
 /**
  * The session established after a successful SMART App Launch.
@@ -62,7 +74,6 @@ export type SmartSession = {
 	encounter?: string | undefined;
 	fhirUser?: string | undefined;
 	idToken?: string | undefined;
-	tokenResponse: SmartTokenResponse;
 };
 
 /**
@@ -349,7 +360,6 @@ const sessionFromTokenResponse = (
 		encounter: token.encounter,
 		fhirUser: token.fhirUser,
 		idToken: token.id_token,
-		tokenResponse: token,
 	};
 };
 
@@ -475,16 +485,22 @@ export async function refreshSession(
 		);
 	}
 
-	const token = (await response.json()) as SmartTokenResponse;
-	const next = sessionFromTokenResponse(session, token);
-	if (!next.refreshToken && session.refreshToken) {
-		next.refreshToken = session.refreshToken;
-		next.tokenResponse = {
-			...next.tokenResponse,
-			refresh_token: session.refreshToken,
-		};
-	}
-	return next;
+	const token = (await response.json()) as SmartRefreshTokenResponse;
+	const refreshToken = session.refreshToken;
+	const expiresAt =
+		token.expires_in !== undefined
+			? Date.now() + token.expires_in * 1000
+			: undefined;
+	const scope = token.scope ?? session.scope;
+	const patient = token.patient ?? session.patient;
+	return {
+		...session,
+		accessToken: token.access_token,
+		refreshToken,
+		expiresAt,
+		scope,
+		patient,
+	};
 }
 
 /**

--- a/packages/aidbox-client/src/smart-app-launch.ts
+++ b/packages/aidbox-client/src/smart-app-launch.ts
@@ -51,7 +51,7 @@ export type SmartTokenResponse<TUser = UserInfo> = {
 export type SmartRefreshTokenResponse = Required<
 	Pick<SmartTokenResponse, "access_token">
 > &
-	Pick<SmartTokenResponse, "expires_in" | "scope" | "patient"> & {
+	Pick<SmartTokenResponse, "expires_in" | "scope" | "patient" | "refresh_token"> & {
 		token_type: "Bearer";
 	};
 
@@ -487,13 +487,13 @@ export async function refreshSession<TUser = UserInfo>(
 	}
 
 	const token = (await response.json()) as SmartRefreshTokenResponse;
-	const refreshToken = session.refreshToken;
 	const expiresAt =
 		token.expires_in !== undefined
 			? Date.now() + token.expires_in * 1000
 			: undefined;
 	const scope = token.scope ?? session.scope;
-	const patient = token.patient ?? session.patient;
+  const patient = token.patient ?? session.patient;
+  const refreshToken = token.refresh_token ?? session.refreshToken;
 	return {
 		...session,
 		accessToken: token.access_token,

--- a/packages/aidbox-client/src/types.ts
+++ b/packages/aidbox-client/src/types.ts
@@ -18,9 +18,19 @@ export type AuthProvider = {
 	establishSession: () => void;
 };
 
+export type AidboxReference = {
+	id: string;
+	resourceType: string;
+};
+
 // FIXME: sansara#6557 Generate from IG
-export type User = Resource & {
+export type User = Omit<Resource, "resourceType"> & {
+	resourceType: "User";
 	email?: string;
+};
+
+export type UserInfo = Omit<User, "fhirUser"> & {
+	fhirUser?: AidboxReference;
 };
 
 export type RequestParams = {

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -327,7 +327,12 @@ describe("exchangeCode", () => {
 				token_type: "Bearer",
 				patient: "Patient/123",
 				scope: "openid fhirUser",
-				fhirUser: "Practitioner/abc",
+				userinfo: {
+					resourceType: "User",
+					id: "user-1",
+					email: "user@example.com",
+					fhirUser: { id: "abc", resourceType: "Practitioner" },
+				},
 			}),
 		);
 		globalThis.fetch = mockFetch;
@@ -351,7 +356,11 @@ describe("exchangeCode", () => {
 		expect(session.accessToken).toBe("access-1");
 		expect(session.refreshToken).toBe("refresh-1");
 		expect(session.patient).toBe("Patient/123");
-		expect(session.fhirUser).toBe("Practitioner/abc");
+		expect(session.userinfo?.email).toBe("user@example.com");
+		expect(session.userinfo?.fhirUser).toEqual({
+			id: "abc",
+			resourceType: "Practitioner",
+		});
 		expect(session.expiresAt).toBeGreaterThan(Date.now());
 	});
 
@@ -463,8 +472,13 @@ describe("refreshSession", () => {
 		scope: "openid",
 		patient: "patient-1",
 		encounter: "encounter-1",
-		fhirUser: "Practitioner/1",
 		idToken: "id-token-1",
+		userinfo: {
+			resourceType: "User",
+			id: "user-1",
+			email: "user@example.com",
+			fhirUser: { id: "1", resourceType: "Practitioner" },
+		},
 	});
 
 	it("should post refresh_token grant and return a fresh session", async () => {
@@ -535,8 +549,11 @@ describe("refreshSession", () => {
 		expect(next.scope).toBe("openid");
 		expect(next.patient).toBe("patient-1");
 		expect(next.encounter).toBe("encounter-1");
-		expect(next.fhirUser).toBe("Practitioner/1");
 		expect(next.idToken).toBe("id-token-1");
+		expect(next.userinfo?.fhirUser).toEqual({
+			id: "1",
+			resourceType: "Practitioner",
+		});
 	});
 
 	it("should throw when no refreshToken is present", async () => {

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -353,7 +353,6 @@ describe("exchangeCode", () => {
 		expect(session.patient).toBe("Patient/123");
 		expect(session.fhirUser).toBe("Practitioner/abc");
 		expect(session.expiresAt).toBeGreaterThan(Date.now());
-		expect(session.tokenResponse.access_token).toBe("access-1");
 	});
 
 	it("should use Basic auth when clientSecret is set, omit client_id from body", async () => {
@@ -462,20 +461,20 @@ describe("refreshSession", () => {
 		refreshToken: "old-refresh",
 		expiresAt: Date.now() + 3_600_000,
 		scope: "openid",
-		tokenResponse: {
-			access_token: "old-access",
-			refresh_token: "old-refresh",
-			expires_in: 3600,
-			scope: "openid",
-		},
+		patient: "patient-1",
+		encounter: "encounter-1",
+		fhirUser: "Practitioner/1",
+		idToken: "id-token-1",
 	});
 
 	it("should post refresh_token grant and return a fresh session", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(
 			jsonResponse({
 				access_token: "new-access",
-				refresh_token: "new-refresh",
+				token_type: "Bearer",
 				expires_in: 3600,
+				scope: "openid",
+				patient: "patient-1",
 			}),
 		);
 		globalThis.fetch = mockFetch;
@@ -489,19 +488,55 @@ describe("refreshSession", () => {
 		expect(body.get("client_id")).toBe(CLIENT_ID);
 
 		expect(next.accessToken).toBe("new-access");
-		expect(next.refreshToken).toBe("new-refresh");
+		expect(next.refreshToken).toBe("old-refresh");
 	});
 
 	it("should preserve previous refreshToken if response omits it", async () => {
-		globalThis.fetch = vi
-			.fn()
-			.mockResolvedValue(
-				jsonResponse({ access_token: "new-access", expires_in: 60 }),
-			);
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			jsonResponse({
+				access_token: "new-access",
+				token_type: "Bearer",
+				expires_in: 60,
+				scope: "openid",
+				patient: "patient-1",
+			}),
+		);
 
 		const next = await refreshSession(sessionWithRefresh());
 		expect(next.refreshToken).toBe("old-refresh");
-		expect(next.tokenResponse.refresh_token).toBe("old-refresh");
+	});
+
+	it("should clear expiresAt if refresh response omits expires_in", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			jsonResponse({
+				access_token: "new-access",
+				token_type: "Bearer",
+				scope: "openid",
+				patient: "patient-1",
+			}),
+		);
+
+		const next = await refreshSession(sessionWithRefresh());
+		expect(next.expiresAt).toBeUndefined();
+	});
+
+	it("should preserve launch context fields omitted by refresh response", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			jsonResponse({
+				access_token: "new-access",
+				token_type: "Bearer",
+				expires_in: 60,
+				scope: "openid",
+				patient: "patient-1",
+			}),
+		);
+
+		const next = await refreshSession(sessionWithRefresh());
+		expect(next.scope).toBe("openid");
+		expect(next.patient).toBe("patient-1");
+		expect(next.encounter).toBe("encounter-1");
+		expect(next.fhirUser).toBe("Practitioner/1");
+		expect(next.idToken).toBe("id-token-1");
 	});
 
 	it("should throw when no refreshToken is present", async () => {
@@ -521,7 +556,6 @@ describe("revokeSession", () => {
 		accessToken: "a",
 		refreshToken: "r",
 		expiresAt: Date.now() + 3_600_000,
-		tokenResponse: { access_token: "a", refresh_token: "r" },
 	});
 
 	it("should POST refresh token to revocation endpoint", async () => {
@@ -563,11 +597,6 @@ describe("SmartAppLaunchAuthProvider", () => {
 		accessToken: "access-fresh",
 		refreshToken: "refresh-1",
 		expiresAt: Date.now() + 3_600_000,
-		tokenResponse: {
-			access_token: "access-fresh",
-			refresh_token: "refresh-1",
-			expires_in: 3600,
-		},
 	});
 
 	const makeStore = (initial: SmartSession) => {
@@ -626,7 +655,7 @@ describe("SmartAppLaunchAuthProvider", () => {
 			if (url === TOKEN_URL) {
 				return jsonResponse({
 					access_token: "fresh-after-refresh",
-					refresh_token: "refresh-2",
+					token_type: "Bearer",
 					expires_in: 3600,
 				});
 			}
@@ -646,6 +675,7 @@ describe("SmartAppLaunchAuthProvider", () => {
 		expect(mockFetch).toHaveBeenCalledTimes(2);
 		expect(store.setSession).toHaveBeenCalledOnce();
 		expect(store.current().accessToken).toBe("fresh-after-refresh");
+		expect(store.current().refreshToken).toBe("refresh-1");
 
 		const fhirCall = mockFetch.mock.calls.find(
 			(c) => (typeof c[0] === "string" ? c[0] : c[0].toString()) !== TOKEN_URL,
@@ -661,7 +691,7 @@ describe("SmartAppLaunchAuthProvider", () => {
 			if (url === TOKEN_URL) {
 				return jsonResponse({
 					access_token: "post-401-token",
-					refresh_token: "refresh-2",
+					token_type: "Bearer",
 					expires_in: 3600,
 				});
 			}
@@ -684,6 +714,7 @@ describe("SmartAppLaunchAuthProvider", () => {
 		expect(r.ok).toBe(true);
 		expect(callsToFhir).toBe(2);
 		expect(store.current().accessToken).toBe("post-401-token");
+		expect(store.current().refreshToken).toBe("refresh-1");
 	});
 
 	it("should not retry after 401 if no refresh token is available", async () => {
@@ -723,7 +754,13 @@ describe("SmartAppLaunchAuthProvider", () => {
 				return new Promise<Response>((resolve) =>
 					setTimeout(
 						() =>
-							resolve(jsonResponse({ access_token: "new", expires_in: 3600 })),
+							resolve(
+								jsonResponse({
+									access_token: "new",
+									token_type: "Bearer",
+									expires_in: 3600,
+								}),
+							),
 						10,
 					),
 				);
@@ -767,11 +804,13 @@ describe("SmartAppLaunchAuthProvider", () => {
 			...freshSession(),
 			expiresAt: Date.now() + 1_000,
 		};
-		globalThis.fetch = vi
-			.fn()
-			.mockResolvedValue(
-				jsonResponse({ access_token: "via-establish", expires_in: 3600 }),
-			);
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			jsonResponse({
+				access_token: "via-establish",
+				token_type: "Bearer",
+				expires_in: 3600,
+			}),
+		);
 
 		const store = makeStore(stale);
 		const provider = new SmartAppLaunchAuthProvider({

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -1,0 +1,771 @@
+import {
+	authorize,
+	exchangeCode,
+	fetchSmartConfiguration,
+	type PendingAuthorization,
+	refreshSession,
+	revokeSession,
+	SmartAppLaunchAuthProvider,
+	type SmartConfiguration,
+	type SmartSession,
+} from "src/smart-app-launch";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const AIDBOX_BASE_URL = "http://localhost:8080";
+
+const ISS = "https://fhir.example.com";
+const AUTHORIZE_URL = "https://auth.example.com/authorize";
+const TOKEN_URL = "https://auth.example.com/token";
+const REVOCATION_URL = "https://auth.example.com/revoke";
+const CLIENT_ID = "test-client";
+const REDIRECT_URI = "https://app.example.com/callback";
+
+const buildSmartConfig = (
+	overrides: Partial<SmartConfiguration> = {},
+): SmartConfiguration => ({
+	authorization_endpoint: AUTHORIZE_URL,
+	token_endpoint: TOKEN_URL,
+	revocation_endpoint: REVOCATION_URL,
+	code_challenge_methods_supported: ["S256"],
+	...overrides,
+});
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("fetchSmartConfiguration", () => {
+	it("should fetch and return the SMART configuration document", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(jsonResponse(buildSmartConfig()));
+		globalThis.fetch = mockFetch;
+
+		const config = await fetchSmartConfiguration(ISS);
+
+		expect(config.token_endpoint).toBe(TOKEN_URL);
+		expect(mockFetch).toHaveBeenCalledOnce();
+		expect(mockFetch.mock.calls[0]?.[0]).toBe(
+			`${ISS}/.well-known/smart-configuration`,
+		);
+	});
+
+	it("should strip trailing slash from iss before requesting", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(jsonResponse(buildSmartConfig()));
+		globalThis.fetch = mockFetch;
+
+		await fetchSmartConfiguration(`${ISS}/`);
+
+		expect(mockFetch.mock.calls[0]?.[0]).toBe(
+			`${ISS}/.well-known/smart-configuration`,
+		);
+	});
+
+	it("should throw on non-OK response", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(new Response("not found", { status: 404 }));
+
+		await expect(fetchSmartConfiguration(ISS)).rejects.toThrow(/404/);
+	});
+
+	it("should throw when required endpoints are missing", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse({ token_endpoint: TOKEN_URL }));
+
+		await expect(fetchSmartConfiguration(ISS)).rejects.toThrow(
+			/missing required endpoints/,
+		);
+	});
+});
+
+describe("authorize", () => {
+	it("should build standalone authorize URL with PKCE when supported", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		const result = await authorize({
+			iss: ISS,
+			clientId: CLIENT_ID,
+			scope: "openid fhirUser patient/*.read",
+			redirectUri: REDIRECT_URI,
+		});
+
+		const url = new URL(result.redirectUrl);
+		expect(`${url.origin}${url.pathname}`).toBe(AUTHORIZE_URL);
+		expect(url.searchParams.get("response_type")).toBe("code");
+		expect(url.searchParams.get("client_id")).toBe(CLIENT_ID);
+		expect(url.searchParams.get("redirect_uri")).toBe(REDIRECT_URI);
+		expect(url.searchParams.get("aud")).toBe(ISS);
+		expect(url.searchParams.get("state")).toBe(result.pending.stateNonce);
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(url.searchParams.get("code_challenge")).toBeTruthy();
+		expect(url.searchParams.get("launch")).toBeNull();
+
+		expect(result.pending.codeVerifier).toBeTruthy();
+		expect(result.pending.codeChallengeMethod).toBe("S256");
+		expect(result.pending.serverUrl).toBe(ISS);
+		expect(result.pending.tokenUri).toBe(TOKEN_URL);
+		expect(result.pending.revocationUri).toBe(REVOCATION_URL);
+	});
+
+	it("should produce different stateNonce and codeVerifier on each call", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockImplementation(async () => jsonResponse(buildSmartConfig()));
+
+		const a = await authorize({
+			iss: ISS,
+			clientId: CLIENT_ID,
+			scope: "openid",
+			redirectUri: REDIRECT_URI,
+		});
+		const b = await authorize({
+			iss: ISS,
+			clientId: CLIENT_ID,
+			scope: "openid",
+			redirectUri: REDIRECT_URI,
+		});
+
+		expect(a.pending.stateNonce).not.toBe(b.pending.stateNonce);
+		expect(a.pending.codeVerifier).not.toBe(b.pending.codeVerifier);
+		expect(a.pending.stateNonce.length).toBeGreaterThanOrEqual(16);
+		expect(a.pending.codeVerifier?.length ?? 0).toBeGreaterThanOrEqual(43);
+	});
+
+	it("should extract iss and launch from launchUrl, overriding config", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		const launchUrl = `https://app.example.com/launch?iss=${encodeURIComponent(ISS)}&launch=abc123`;
+		const result = await authorize({
+			iss: "https://wrong.example.com",
+			clientId: CLIENT_ID,
+			scope: "openid fhirUser",
+			redirectUri: REDIRECT_URI,
+			launchUrl,
+		});
+
+		const url = new URL(result.redirectUrl);
+		expect(url.searchParams.get("aud")).toBe(ISS);
+		expect(url.searchParams.get("launch")).toBe("abc123");
+		expect(url.searchParams.get("scope")).toContain("launch");
+		expect(result.pending.serverUrl).toBe(ISS);
+	});
+
+	it("should not duplicate `launch` scope if already present", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		const result = await authorize({
+			clientId: CLIENT_ID,
+			scope: "launch openid",
+			redirectUri: REDIRECT_URI,
+			launchUrl: `https://x/launch?iss=${encodeURIComponent(ISS)}&launch=l1`,
+		});
+		const url = new URL(result.redirectUrl);
+		const scopes = url.searchParams.get("scope")?.split(" ") ?? [];
+		expect(scopes.filter((s) => s === "launch").length).toBe(1);
+	});
+
+	it("should disable PKCE when pkceMode is 'disabled'", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		const result = await authorize({
+			iss: ISS,
+			clientId: CLIENT_ID,
+			scope: "openid",
+			redirectUri: REDIRECT_URI,
+			pkceMode: "disabled",
+		});
+
+		const url = new URL(result.redirectUrl);
+		expect(url.searchParams.get("code_challenge")).toBeNull();
+		expect(result.pending.codeVerifier).toBeUndefined();
+	});
+
+	it("should throw when pkceMode is 'required' but server doesn't advertise S256", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			jsonResponse(
+				buildSmartConfig({ code_challenge_methods_supported: undefined }),
+			),
+		);
+
+		await expect(
+			authorize({
+				iss: ISS,
+				clientId: CLIENT_ID,
+				scope: "openid",
+				redirectUri: REDIRECT_URI,
+				pkceMode: "required",
+			}),
+		).rejects.toThrow(/pkceMode=required/);
+	});
+
+	it("should disable PKCE when 'ifSupported' and server does not advertise S256", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				jsonResponse(buildSmartConfig({ code_challenge_methods_supported: [] })),
+			);
+
+		const result = await authorize({
+			iss: ISS,
+			clientId: CLIENT_ID,
+			scope: "openid",
+			redirectUri: REDIRECT_URI,
+		});
+		expect(result.pending.codeVerifier).toBeUndefined();
+	});
+
+	it("should require iss either in config or launchUrl", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		await expect(
+			authorize({
+				clientId: CLIENT_ID,
+				scope: "openid",
+				redirectUri: REDIRECT_URI,
+			}),
+		).rejects.toThrow(/requires `iss`/);
+	});
+
+	it("should reject iss not matching issMatch string", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		await expect(
+			authorize({
+				iss: "https://evil.example.com",
+				clientId: CLIENT_ID,
+				scope: "openid",
+				redirectUri: REDIRECT_URI,
+				issMatch: ISS,
+			}),
+		).rejects.toThrow(/issMatch rejected/);
+	});
+
+	it("should accept iss matching issMatch RegExp", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		await expect(
+			authorize({
+				iss: ISS,
+				clientId: CLIENT_ID,
+				scope: "openid",
+				redirectUri: REDIRECT_URI,
+				issMatch: /^https:\/\/fhir\./,
+			}),
+		).resolves.toBeDefined();
+	});
+});
+
+describe("exchangeCode", () => {
+	const basePending = (): PendingAuthorization => ({
+		serverUrl: ISS,
+		clientId: CLIENT_ID,
+		redirectUri: REDIRECT_URI,
+		scope: "openid",
+		authorizeUri: AUTHORIZE_URL,
+		tokenUri: TOKEN_URL,
+		revocationUri: REVOCATION_URL,
+		stateNonce: "nonce-123",
+		codeVerifier: "verifier-xyz",
+		codeChallengeMethod: "S256",
+	});
+
+	it("should post code+verifier to token endpoint and return a session", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(
+			jsonResponse({
+				access_token: "access-1",
+				refresh_token: "refresh-1",
+				expires_in: 3600,
+				token_type: "Bearer",
+				patient: "Patient/123",
+				scope: "openid fhirUser",
+				fhirUser: "Practitioner/abc",
+			}),
+		);
+		globalThis.fetch = mockFetch;
+
+		const session = await exchangeCode({
+			url: `${REDIRECT_URI}?code=auth-code&state=nonce-123`,
+			pending: basePending(),
+		});
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+		const [calledUrl, init] = mockFetch.mock.calls[0] ?? [];
+		expect(calledUrl).toBe(TOKEN_URL);
+		expect(init.method).toBe("POST");
+		const body = new URLSearchParams(init.body as string);
+		expect(body.get("grant_type")).toBe("authorization_code");
+		expect(body.get("code")).toBe("auth-code");
+		expect(body.get("code_verifier")).toBe("verifier-xyz");
+		expect(body.get("client_id")).toBe(CLIENT_ID);
+		expect(body.get("redirect_uri")).toBe(REDIRECT_URI);
+
+		expect(session.accessToken).toBe("access-1");
+		expect(session.refreshToken).toBe("refresh-1");
+		expect(session.patient).toBe("Patient/123");
+		expect(session.fhirUser).toBe("Practitioner/abc");
+		expect(session.expiresAt).toBeGreaterThan(Date.now());
+		expect(session.tokenResponse.access_token).toBe("access-1");
+	});
+
+	it("should use Basic auth when clientSecret is set, omit client_id from body", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse({ access_token: "a", expires_in: 60 }));
+		globalThis.fetch = mockFetch;
+
+		await exchangeCode({
+			url: `${REDIRECT_URI}?code=c&state=nonce-123`,
+			pending: { ...basePending(), clientSecret: "secret" },
+		});
+
+		const init = mockFetch.mock.calls[0]?.[1];
+		const headers = new Headers(init.headers);
+		expect(headers.get("authorization")?.startsWith("Basic ")).toBe(true);
+		const body = new URLSearchParams(init.body as string);
+		expect(body.get("client_id")).toBeNull();
+	});
+
+	it("should reject when state nonce does not match", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({}));
+
+		await expect(
+			exchangeCode({
+				url: `${REDIRECT_URI}?code=c&state=wrong`,
+				pending: basePending(),
+			}),
+		).rejects.toThrow(/state.*does not match/);
+	});
+
+	it("should reject when callback has no code", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({}));
+
+		await expect(
+			exchangeCode({
+				url: `${REDIRECT_URI}?state=nonce-123`,
+				pending: basePending(),
+			}),
+		).rejects.toThrow(/missing `code`/);
+	});
+
+	it("should surface OAuth error from callback URL", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({}));
+
+		await expect(
+			exchangeCode({
+				url: `${REDIRECT_URI}?error=access_denied&error_description=user%20said%20no&state=nonce-123`,
+				pending: basePending(),
+			}),
+		).rejects.toThrow(/access_denied.*user said no/);
+	});
+
+	it("should throw on non-OK token response", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(new Response("invalid_grant", { status: 400 }));
+
+		await expect(
+			exchangeCode({
+				url: `${REDIRECT_URI}?code=c&state=nonce-123`,
+				pending: basePending(),
+			}),
+		).rejects.toThrow(/Token endpoint returned 400/);
+	});
+});
+
+describe("refreshSession", () => {
+	const sessionWithRefresh = (): SmartSession => ({
+		serverUrl: ISS,
+		clientId: CLIENT_ID,
+		tokenUri: TOKEN_URL,
+		revocationUri: REVOCATION_URL,
+		accessToken: "old-access",
+		refreshToken: "old-refresh",
+		expiresAt: Date.now() + 3_600_000,
+		scope: "openid",
+		tokenResponse: {
+			access_token: "old-access",
+			refresh_token: "old-refresh",
+			expires_in: 3600,
+			scope: "openid",
+		},
+	});
+
+	it("should post refresh_token grant and return a fresh session", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(
+			jsonResponse({
+				access_token: "new-access",
+				refresh_token: "new-refresh",
+				expires_in: 3600,
+			}),
+		);
+		globalThis.fetch = mockFetch;
+
+		const next = await refreshSession(sessionWithRefresh());
+
+		const init = mockFetch.mock.calls[0]?.[1];
+		const body = new URLSearchParams(init.body as string);
+		expect(body.get("grant_type")).toBe("refresh_token");
+		expect(body.get("refresh_token")).toBe("old-refresh");
+		expect(body.get("client_id")).toBe(CLIENT_ID);
+
+		expect(next.accessToken).toBe("new-access");
+		expect(next.refreshToken).toBe("new-refresh");
+	});
+
+	it("should preserve previous refreshToken if response omits it", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				jsonResponse({ access_token: "new-access", expires_in: 60 }),
+			);
+
+		const next = await refreshSession(sessionWithRefresh());
+		expect(next.refreshToken).toBe("old-refresh");
+		expect(next.tokenResponse.refresh_token).toBe("old-refresh");
+	});
+
+	it("should throw when no refreshToken is present", async () => {
+		const session = sessionWithRefresh();
+		session.refreshToken = undefined;
+
+		await expect(refreshSession(session)).rejects.toThrow(/no refreshToken/);
+	});
+});
+
+describe("revokeSession", () => {
+	const baseSession = (): SmartSession => ({
+		serverUrl: ISS,
+		clientId: CLIENT_ID,
+		tokenUri: TOKEN_URL,
+		revocationUri: REVOCATION_URL,
+		accessToken: "a",
+		refreshToken: "r",
+		expiresAt: Date.now() + 3_600_000,
+		tokenResponse: { access_token: "a", refresh_token: "r" },
+	});
+
+	it("should POST refresh token to revocation endpoint", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+		globalThis.fetch = mockFetch;
+
+		await revokeSession(baseSession());
+
+		const [url, init] = mockFetch.mock.calls[0] ?? [];
+		expect(url).toBe(REVOCATION_URL);
+		const body = new URLSearchParams(init.body as string);
+		expect(body.get("token")).toBe("r");
+	});
+
+	it("should be a no-op when revocationUri is missing", async () => {
+		const mockFetch = vi.fn();
+		globalThis.fetch = mockFetch;
+
+		const session = baseSession();
+		session.revocationUri = undefined;
+		await revokeSession(session);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it("should swallow network errors", async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+		await expect(revokeSession(baseSession())).resolves.toBeUndefined();
+	});
+});
+
+describe("SmartAppLaunchAuthProvider", () => {
+	const freshSession = (): SmartSession => ({
+		serverUrl: ISS,
+		clientId: CLIENT_ID,
+		tokenUri: TOKEN_URL,
+		revocationUri: REVOCATION_URL,
+		accessToken: "access-fresh",
+		refreshToken: "refresh-1",
+		expiresAt: Date.now() + 3_600_000,
+		tokenResponse: {
+			access_token: "access-fresh",
+			refresh_token: "refresh-1",
+			expires_in: 3600,
+		},
+	});
+
+	const makeStore = (initial: SmartSession) => {
+		let session = initial;
+		return {
+			getSession: vi.fn(() => session),
+			setSession: vi.fn((s: SmartSession) => {
+				session = s;
+			}),
+			current: () => session,
+		};
+	};
+
+	it("should attach Bearer header to outgoing requests", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+		globalThis.fetch = mockFetch;
+
+		const store = makeStore(freshSession());
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		const response = await provider.fetch(`${ISS}/Patient`);
+
+		expect(response.ok).toBe(true);
+		const headers = mockFetch.mock.calls[0]?.[1].headers as Headers;
+		expect(headers.get("Authorization")).toBe("Bearer access-fresh");
+		expect(store.getSession).toHaveBeenCalled();
+	});
+
+	it("should reject requests not starting with baseUrl", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(new Response("{}"));
+
+		const store = makeStore(freshSession());
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		await expect(
+			provider.fetch("https://other.example.com/Patient"),
+		).rejects.toThrow(/must start with baseUrl/);
+	});
+
+	it("should auto-refresh when token is near expiry and call setSession", async () => {
+		const stale: SmartSession = {
+			...freshSession(),
+			expiresAt: Date.now() + 1_000,
+		};
+
+		const mockFetch = vi.fn().mockImplementation(async (input) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === TOKEN_URL) {
+				return jsonResponse({
+					access_token: "fresh-after-refresh",
+					refresh_token: "refresh-2",
+					expires_in: 3600,
+				});
+			}
+			return new Response("{}", { status: 200 });
+		});
+		globalThis.fetch = mockFetch;
+
+		const store = makeStore(stale);
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		const r = await provider.fetch(`${ISS}/Patient`);
+
+		expect(r.ok).toBe(true);
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+		expect(store.setSession).toHaveBeenCalledOnce();
+		expect(store.current().accessToken).toBe("fresh-after-refresh");
+
+		const fhirCall = mockFetch.mock.calls.find(
+			(c) => (typeof c[0] === "string" ? c[0] : c[0].toString()) !== TOKEN_URL,
+		);
+		const headers = fhirCall?.[1].headers as Headers;
+		expect(headers.get("Authorization")).toBe("Bearer fresh-after-refresh");
+	});
+
+	it("should retry once after 401 with refreshed token", async () => {
+		let callsToFhir = 0;
+		const mockFetch = vi.fn().mockImplementation(async (input) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === TOKEN_URL) {
+				return jsonResponse({
+					access_token: "post-401-token",
+					refresh_token: "refresh-2",
+					expires_in: 3600,
+				});
+			}
+			callsToFhir++;
+			if (callsToFhir === 1) {
+				return new Response("unauthorized", { status: 401 });
+			}
+			return new Response("{}", { status: 200 });
+		});
+		globalThis.fetch = mockFetch;
+
+		const store = makeStore(freshSession());
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		const r = await provider.fetch(`${ISS}/Patient`);
+
+		expect(r.ok).toBe(true);
+		expect(callsToFhir).toBe(2);
+		expect(store.current().accessToken).toBe("post-401-token");
+	});
+
+	it("should not retry after 401 if no refresh token is available", async () => {
+		const session: SmartSession = {
+			...freshSession(),
+			refreshToken: undefined,
+		};
+
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("unauthorized", { status: 401 }));
+		globalThis.fetch = mockFetch;
+
+		const store = makeStore(session);
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		const r = await provider.fetch(`${ISS}/Patient`);
+
+		expect(r.status).toBe(401);
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("should deduplicate concurrent refreshes", async () => {
+		const stale: SmartSession = {
+			...freshSession(),
+			expiresAt: Date.now() + 1_000,
+		};
+
+		let tokenCalls = 0;
+		const mockFetch = vi.fn().mockImplementation(async (input) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === TOKEN_URL) {
+				tokenCalls++;
+				return new Promise<Response>((resolve) =>
+					setTimeout(
+						() =>
+							resolve(jsonResponse({ access_token: "new", expires_in: 3600 })),
+						10,
+					),
+				);
+			}
+			return new Response("{}", { status: 200 });
+		});
+		globalThis.fetch = mockFetch;
+
+		const store = makeStore(stale);
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		await Promise.all([
+			provider.fetch(`${ISS}/A`),
+			provider.fetch(`${ISS}/B`),
+			provider.fetch(`${ISS}/C`),
+		]);
+
+		expect(tokenCalls).toBe(1);
+	});
+
+	it("should be a no-op for establishSession when token is fresh", async () => {
+		const mockFetch = vi.fn();
+		globalThis.fetch = mockFetch;
+
+		const store = makeStore(freshSession());
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		await provider.establishSession();
+
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it("should refresh on establishSession when token is stale", async () => {
+		const stale: SmartSession = {
+			...freshSession(),
+			expiresAt: Date.now() + 1_000,
+		};
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				jsonResponse({ access_token: "via-establish", expires_in: 3600 }),
+			);
+
+		const store = makeStore(stale);
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		await provider.establishSession();
+
+		expect(store.current().accessToken).toBe("via-establish");
+	});
+
+	it("should throw on establishSession when session is expired and has no refreshToken", async () => {
+		const expired: SmartSession = {
+			...freshSession(),
+			expiresAt: Date.now() - 1_000,
+			refreshToken: undefined,
+		};
+
+		const store = makeStore(expired);
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		await expect(provider.establishSession()).rejects.toThrow(
+			/expired and has no refreshToken/,
+		);
+	});
+
+	it("should call revocation endpoint on revokeSession", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+		globalThis.fetch = mockFetch;
+
+		const store = makeStore(freshSession());
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+		});
+		await provider.revokeSession();
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+		expect(mockFetch.mock.calls[0]?.[0]).toBe(REVOCATION_URL);
+	});
+});
+
+describe("SMART discovery against live Aidbox", () => {
+	it("should fetch the SMART configuration document from Aidbox", async () => {
+		const config = await fetchSmartConfiguration(AIDBOX_BASE_URL);
+
+		expect(typeof config.authorization_endpoint).toBe("string");
+		expect(config.authorization_endpoint.length).toBeGreaterThan(0);
+		expect(typeof config.token_endpoint).toBe("string");
+		expect(config.token_endpoint.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -46,7 +46,9 @@ afterEach(() => {
 
 describe("fetchSmartConfiguration", () => {
 	it("should fetch and return the SMART configuration document", async () => {
-		const mockFetch = vi.fn().mockResolvedValue(jsonResponse(buildSmartConfig()));
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
 		globalThis.fetch = mockFetch;
 
 		const config = await fetchSmartConfiguration(ISS);
@@ -59,7 +61,9 @@ describe("fetchSmartConfiguration", () => {
 	});
 
 	it("should strip trailing slash from iss before requesting", async () => {
-		const mockFetch = vi.fn().mockResolvedValue(jsonResponse(buildSmartConfig()));
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
 		globalThis.fetch = mockFetch;
 
 		await fetchSmartConfiguration(`${ISS}/`);
@@ -199,11 +203,13 @@ describe("authorize", () => {
 	});
 
 	it("should throw when pkceMode is 'required' but server doesn't advertise S256", async () => {
-		globalThis.fetch = vi.fn().mockResolvedValue(
-			jsonResponse(
-				buildSmartConfig({ code_challenge_methods_supported: undefined }),
-			),
-		);
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				jsonResponse(
+					buildSmartConfig({ code_challenge_methods_supported: undefined }),
+				),
+			);
 
 		await expect(
 			authorize({
@@ -220,7 +226,9 @@ describe("authorize", () => {
 		globalThis.fetch = vi
 			.fn()
 			.mockResolvedValue(
-				jsonResponse(buildSmartConfig({ code_challenge_methods_supported: [] })),
+				jsonResponse(
+					buildSmartConfig({ code_challenge_methods_supported: [] }),
+				),
 			);
 
 		const result = await authorize({
@@ -469,7 +477,9 @@ describe("revokeSession", () => {
 	});
 
 	it("should POST refresh token to revocation endpoint", async () => {
-		const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("", { status: 200 }));
 		globalThis.fetch = mockFetch;
 
 		await revokeSession(baseSession());
@@ -524,7 +534,9 @@ describe("SmartAppLaunchAuthProvider", () => {
 	};
 
 	it("should attach Bearer header to outgoing requests", async () => {
-		const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("{}", { status: 200 }));
 		globalThis.fetch = mockFetch;
 
 		const store = makeStore(freshSession());
@@ -743,7 +755,9 @@ describe("SmartAppLaunchAuthProvider", () => {
 	});
 
 	it("should call revocation endpoint on revokeSession", async () => {
-		const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("", { status: 200 }));
 		globalThis.fetch = mockFetch;
 
 		const store = makeStore(freshSession());

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -374,6 +374,37 @@ describe("exchangeCode", () => {
 		expect(body.get("client_id")).toBeNull();
 	});
 
+	it("should accept callback iss matching the expected authorization server issuer", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse({ access_token: "a", expires_in: 60 }));
+		globalThis.fetch = mockFetch;
+
+		await exchangeCode({
+			url: `${REDIRECT_URI}?code=c&state=nonce-123&iss=${encodeURIComponent("https://auth.example.com")}`,
+			pending: {
+				...basePending(),
+				authorizationServerIssuer: "https://auth.example.com",
+			},
+		});
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+	});
+
+	it("should reject callback iss that does not match the expected authorization server issuer", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({}));
+
+		await expect(
+			exchangeCode({
+				url: `${REDIRECT_URI}?code=c&state=nonce-123&iss=${encodeURIComponent("https://evil.example.com")}`,
+				pending: {
+					...basePending(),
+					authorizationServerIssuer: "https://auth.example.com",
+				},
+			}),
+		).rejects.toThrow(/does not match expected authorization server issuer/);
+	});
+
 	it("should reject when state nonce does not match", async () => {
 		globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({}));
 

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -121,6 +121,25 @@ describe("authorize", () => {
 		expect(result.pending.serverUrl).toBe(ISS);
 		expect(result.pending.tokenUri).toBe(TOKEN_URL);
 		expect(result.pending.revocationUri).toBe(REVOCATION_URL);
+		expect(result.pending.usesClientSecret).toBeUndefined();
+		expect("clientSecret" in result.pending).toBe(false);
+	});
+
+	it("should mark confidential clients without persisting the secret", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		const result = await authorize({
+			iss: ISS,
+			clientId: CLIENT_ID,
+			clientSecret: "secret",
+			scope: "openid",
+			redirectUri: REDIRECT_URI,
+		});
+
+		expect(result.pending.usesClientSecret).toBe(true);
+		expect("clientSecret" in result.pending).toBe(false);
 	});
 
 	it("should produce different stateNonce and codeVerifier on each call", async () => {
@@ -370,9 +389,13 @@ describe("exchangeCode", () => {
 			.mockResolvedValue(jsonResponse({ access_token: "a", expires_in: 60 }));
 		globalThis.fetch = mockFetch;
 
-		await exchangeCode({
+		const session = await exchangeCode({
 			url: `${REDIRECT_URI}?code=c&state=nonce-123`,
-			pending: { ...basePending(), clientSecret: "secret" },
+			pending: {
+				...basePending(),
+				usesClientSecret: true,
+			},
+			clientSecret: "secret",
 		});
 
 		const init = mockFetch.mock.calls[0]?.[1];
@@ -380,6 +403,21 @@ describe("exchangeCode", () => {
 		expect(headers.get("authorization")?.startsWith("Basic ")).toBe(true);
 		const body = new URLSearchParams(init.body as string);
 		expect(body.get("client_id")).toBeNull();
+		expect(session.usesClientSecret).toBe(true);
+	});
+
+	it("should require explicit clientSecret when pending uses client secret", async () => {
+		globalThis.fetch = vi.fn();
+
+		await expect(
+			exchangeCode({
+				url: `${REDIRECT_URI}?code=c&state=nonce-123`,
+				pending: {
+					...basePending(),
+					usesClientSecret: true,
+				},
+			}),
+		).rejects.toThrow(/exchangeCode\(\).*clientSecret/);
 	});
 
 	it("should accept callback iss matching the expected authorization server issuer", async () => {
@@ -484,7 +522,7 @@ describe("refreshSession", () => {
 	it("should post refresh_token grant and return a fresh session", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(
 			jsonResponse({
-        access_token: "new-access",
+				access_token: "new-access",
 				token_type: "Bearer",
 				expires_in: 3600,
 				scope: "openid",
@@ -503,6 +541,29 @@ describe("refreshSession", () => {
 
 		expect(next.accessToken).toBe("new-access");
 		expect(next.refreshToken).toBe("old-refresh");
+	});
+
+	it("should use Basic auth when session uses client secret", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				jsonResponse({ access_token: "new-access", token_type: "Bearer" }),
+			);
+		globalThis.fetch = mockFetch;
+
+		await refreshSession(
+			{
+				...sessionWithRefresh(),
+				usesClientSecret: true,
+			},
+			{ clientSecret: "secret" },
+		);
+
+		const init = mockFetch.mock.calls[0]?.[1];
+		const headers = new Headers(init.headers);
+		expect(headers.get("authorization")?.startsWith("Basic ")).toBe(true);
+		const body = new URLSearchParams(init.body as string);
+		expect(body.get("client_id")).toBeNull();
 	});
 
 	it("should preserve previous refreshToken if response omits it", async () => {
@@ -578,6 +639,17 @@ describe("refreshSession", () => {
 
 		await expect(refreshSession(session)).rejects.toThrow(/no refreshToken/);
 	});
+
+	it("should require explicit clientSecret when session uses client secret", async () => {
+		globalThis.fetch = vi.fn();
+
+		await expect(
+			refreshSession({
+				...sessionWithRefresh(),
+				usesClientSecret: true,
+			}),
+		).rejects.toThrow(/refreshSession\(\).*clientSecret/);
+	});
 });
 
 describe("revokeSession", () => {
@@ -603,6 +675,27 @@ describe("revokeSession", () => {
 		expect(url).toBe(REVOCATION_URL);
 		const body = new URLSearchParams(init.body as string);
 		expect(body.get("token")).toBe("r");
+	});
+
+	it("should use Basic auth for revocation when session uses client secret", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("", { status: 200 }));
+		globalThis.fetch = mockFetch;
+
+		await revokeSession(
+			{
+				...baseSession(),
+				usesClientSecret: true,
+			},
+			{ clientSecret: "secret" },
+		);
+
+		const init = mockFetch.mock.calls[0]?.[1];
+		const headers = new Headers(init.headers);
+		expect(headers.get("authorization")?.startsWith("Basic ")).toBe(true);
+		const body = new URLSearchParams(init.body as string);
+		expect(body.get("client_id")).toBeNull();
 	});
 
 	it("should be a no-op when revocationUri is missing", async () => {
@@ -715,6 +808,42 @@ describe("SmartAppLaunchAuthProvider", () => {
 		);
 		const headers = fhirCall?.[1].headers as Headers;
 		expect(headers.get("Authorization")).toBe("Bearer fresh-after-refresh");
+	});
+
+	it("should use getClientSecret when refreshing confidential client sessions", async () => {
+		const stale: SmartSession = {
+			...freshSession(),
+			usesClientSecret: true,
+			expiresAt: Date.now() + 1_000,
+		};
+
+		const mockFetch = vi.fn().mockImplementation(async (input, init) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === TOKEN_URL) {
+				const headers = new Headers(init?.headers);
+				expect(headers.get("authorization")?.startsWith("Basic ")).toBe(true);
+				return jsonResponse({
+					access_token: "fresh-after-refresh",
+					token_type: "Bearer",
+					expires_in: 3600,
+				});
+			}
+			return new Response("{}", { status: 200 });
+		});
+		globalThis.fetch = mockFetch;
+
+		const getClientSecret = vi.fn(async () => "secret");
+		const store = makeStore(stale);
+		const provider = new SmartAppLaunchAuthProvider({
+			baseUrl: ISS,
+			getSession: store.getSession,
+			setSession: store.setSession,
+			getClientSecret,
+		});
+		const response = await provider.fetch(`${ISS}/Patient`);
+
+		expect(response.ok).toBe(true);
+		expect(getClientSecret).toHaveBeenCalledOnce();
 	});
 
 	it("should retry once after 401 with refreshed token", async () => {

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -484,7 +484,7 @@ describe("refreshSession", () => {
 	it("should post refresh_token grant and return a fresh session", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(
 			jsonResponse({
-				access_token: "new-access",
+        access_token: "new-access",
 				token_type: "Bearer",
 				expires_in: 3600,
 				scope: "openid",
@@ -518,6 +518,22 @@ describe("refreshSession", () => {
 
 		const next = await refreshSession(sessionWithRefresh());
 		expect(next.refreshToken).toBe("old-refresh");
+	});
+
+	it("should get refreshToken if response has it", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			jsonResponse({
+				access_token: "new-access",
+				refresh_token: "new-refresh",
+				token_type: "Bearer",
+				expires_in: 60,
+				scope: "openid",
+				patient: "patient-1",
+			}),
+		);
+
+		const next = await refreshSession(sessionWithRefresh());
+		expect(next.refreshToken).toBe("new-refresh");
 	});
 
 	it("should clear expiresAt if refresh response omits expires_in", async () => {

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -184,6 +184,23 @@ describe("authorize", () => {
 		expect(scopes.filter((s) => s === "launch").length).toBe(1);
 	});
 
+	it("should append `launch` when only `launch/patient` scope is present", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(buildSmartConfig()));
+
+		const result = await authorize({
+			clientId: CLIENT_ID,
+			scope: "launch/patient openid",
+			redirectUri: REDIRECT_URI,
+			launchUrl: `https://x/launch?iss=${encodeURIComponent(ISS)}&launch=l1`,
+		});
+		const url = new URL(result.redirectUrl);
+		const scopes = url.searchParams.get("scope")?.split(" ") ?? [];
+		expect(scopes).toContain("launch/patient");
+		expect(scopes).toContain("launch");
+	});
+
 	it("should disable PKCE when pkceMode is 'disabled'", async () => {
 		globalThis.fetch = vi
 			.fn()


### PR DESCRIPTION


  The SDK already supports SMART Backend Services (server-to-server client_credentials), but had no way to authenticate as a provider-facing app on behalf of a user. This adds the authorization_code grant with PKCE for SMART App Launch — the standard
   way to build EHR-launched and standalone provider apps on top of Aidbox.

  Covers both launch modes:
  - EHR launch — Aidbox redirects the user to the app with ?iss=...&launch=...
  - Standalone launch — the user opens the app directly and the app picks the FHIR server

  Works in both browsers and server apps (Bun/Node) — the provider is storage-agnostic and asks the host for the current session via callbacks, so any session backend (cookie session, Redis, sessionStorage, …) works.


## Affected packages

- [x] `@health-samurai/aidbox-client`
- [ ] `@health-samurai/react-components`
- [ ] `@health-samurai/aidbox-fhirpath-lsp`
