### PR TITLE
fhirpath-lsp: paginate StructureDefinition search with _count=1000

### DIFF
--- a/packages/aidbox-fhirpath-lsp/src/hooks.ts
+++ b/packages/aidbox-fhirpath-lsp/src/hooks.ts
@@ -688,7 +688,10 @@ export function createCodeMirrorLsp(
 		const response = await client.request<Bundle>({
 			method: "GET",
 			url: "/fhir/StructureDefinition",
-			params: [["kind", kind]],
+			params: [
+				["kind", kind],
+				["_count", "1000"],
+			],
 		});
 
 		if (!response.ok) {


### PR DESCRIPTION
## Summary
- `aidbox-fhirpath-lsp` `search()` fetched `/fhir/StructureDefinition?kind=resource` without `_count` and without paginating
- Aidbox defaults to 100 entries per page and does not always return a `link.next`
- On instances with >100 SDs, `getResourceTypes()` did not include common resources like `Patient` or `Resource`, so completion-provider hid functions constrained to FHIR `Resource` (notably `getResourceKey`, `getReferenceKey`)
- Added `_count=1000` so the existing single-page fetch covers practical installations until proper pagination is implemented

## Test plan
- [ ] Open the ViewDefinition Builder on an Aidbox instance with >100 `StructureDefinition` resources where it previously did not show `getResourceKey`
- [ ] In a `COLUMN` path input, type `get` and confirm `getResourceKey` and `getReferenceKey` appear in suggestions