### PR TITLE
feat(react-components): add size variant to Badge

### DIFF
--- a/packages/react-components/src/shadcn/components/ui/badge.stories.tsx
+++ b/packages/react-components/src/shadcn/components/ui/badge.stories.tsx
@@ -18,6 +18,17 @@ export const Demo = {
 				<Badge variant="destructive">Destructive</Badge>
 				<Badge variant="outline">Outline</Badge>
 			</div>
+			<div className="flex w-full flex-wrap items-center gap-2">
+				<Badge size="regular">Regular</Badge>
+				<Badge size="large">Large</Badge>
+				<Badge size="large" variant="secondary">
+					<BadgeCheckIcon />
+					Large with icon
+				</Badge>
+				<Badge size="large" variant="outline">
+					Large outline
+				</Badge>
+			</div>
 			<div className="flex w-full flex-wrap gap-2">
 				<Badge
 					variant="secondary"

--- a/packages/react-components/src/shadcn/components/ui/badge.tsx
+++ b/packages/react-components/src/shadcn/components/ui/badge.tsx
@@ -19,14 +19,9 @@ const baseBadgeStyles = cn(
 	"rounded-md",
 	// Borders
 	"border",
-	// Spacing
-	"px-2",
-	"py-0.5",
 	// Typography
-	"text-xs",
 	"font-medium",
 	// SVG
-	"[&>svg]:size-3",
 	"[&>svg]:pointer-events-none",
 	// Transitions
 	"transition-[color,box-shadow]",
@@ -68,15 +63,25 @@ const badgeVariants = cva(baseBadgeStyles, {
 				"[a&]:hover:text-text-primary",
 			),
 		},
+		// `regular` reproduces the previous hard-coded spacing and type, so
+		// existing usages render identically. `large` is for badges that sit
+		// beside a heading or carry a page-level status, where text-xs is too
+		// quiet to read as a peer of the title next to it.
+		size: {
+			regular: cn("px-2", "py-0.5", "text-xs", "[&>svg]:size-3"),
+			large: cn("px-2.5", "py-1", "text-sm", "[&>svg]:size-3.5"),
+		},
 	},
 	defaultVariants: {
 		variant: "default",
+		size: "regular",
 	},
 });
 
 function Badge({
 	className,
 	variant,
+	size,
 	asChild = false,
 	...props
 }: React.ComponentProps<"span"> &
@@ -86,7 +91,7 @@ function Badge({
 	return (
 		<Comp
 			data-slot="badge"
-			className={cn(badgeVariants({ variant }), className)}
+			className={cn(badgeVariants({ variant, size }), className)}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
## Problem

`Badge` hard-codes its spacing and type in the base styles (`px-2 py-0.5 text-xs`) and exposes no `size` prop — only `variant`. Anything larger has to be patched at the call site via `className`, so each consumer ends up with its own ad-hoc numbers.

Concretely: on the Smartbox admin app-review screen, badges sit next to the app name as its status and classification. At `text-xs` they read as a footnote rather than as peers of the heading beside them.

## Change

Spacing/type move out of the base into a `size` variant with two steps:

| size | classes |
|---|---|
| `regular` (default) | `px-2 py-0.5 text-xs` + `[&>svg]:size-3` |
| `large` | `px-2.5 py-1 text-sm` + `[&>svg]:size-3.5` |

`regular` reproduces the previous values exactly and is the default, so **existing usages render identically** — no visual diff anywhere in any consumer.

Naming follows `Button`, which already defaults to `size: "regular"`.

## Notes

- Icon sizing follows the step, so an icon inside a `large` badge doesn't stay undersized.
- Storybook `Component/Badge` gains a row demonstrating both sizes, including `large` with an icon.
- `biome check` passes on both touched files.