### PR TITLE
support AIDBOX_PORT in integration tests

### DIFF
--- a/.github/workflows/aidbox-client.yaml
+++ b/.github/workflows/aidbox-client.yaml
@@ -42,5 +42,7 @@ jobs:
         working-directory: packages/aidbox-client
 
       - name: Run tests
+        env:
+          AIDBOX_BASE_URL: http://localhost:8080
         run: pnpm test
         working-directory: packages/aidbox-client

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,16 +37,21 @@ pnpm -r run build   # initial build (required for cross-package types)
 3. **Run tests** (currently `aidbox-client` only):
    ```bash
    cd packages/aidbox-client
-   docker compose up --wait   # integration tests need a running Aidbox
    pnpm test
    ```
 
-   If port 8080 is already taken, set `AIDBOX_PORT` — both the compose file and
-   the tests read it:
+   The suite starts its own Aidbox on a free port and removes it afterwards, so
+   nothing needs to be running first and no port can be taken. `BOX_LICENSE` has
+   to be in the environment for that instance to activate.
+
+   Booting an instance costs about a minute. To iterate against one you keep
+   running, point the suite at it:
    ```bash
    AIDBOX_PORT=18080 docker compose up --wait
-   AIDBOX_PORT=18080 pnpm test
+   AIDBOX_BASE_URL=http://localhost:18080 pnpm test
    ```
+   The tests truncate tables, so an instance given this way is checked against
+   `resources/bundle.json` first and the run is refused if it does not match.
 
 4. **Preview UI changes** with Storybook:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,15 @@ pnpm -r run build   # initial build (required for cross-package types)
 3. **Run tests** (currently `aidbox-client` only):
    ```bash
    cd packages/aidbox-client
+   docker compose up --wait   # integration tests need a running Aidbox
    pnpm test
+   ```
+
+   If port 8080 is already taken, set `AIDBOX_PORT` — both the compose file and
+   the tests read it:
+   ```bash
+   AIDBOX_PORT=18080 docker compose up --wait
+   AIDBOX_PORT=18080 pnpm test
    ```
 
 4. **Preview UI changes** with Storybook:

--- a/packages/aidbox-client/docker-compose.yaml
+++ b/packages/aidbox-client/docker-compose.yaml
@@ -47,9 +47,10 @@ services:
       BOX_SECURITY_AUDIT_LOG_ENABLED: 'true'
       BOX_SECURITY_DEV_MODE: 'true'
       BOX_SETTINGS_MODE: read-write
-      BOX_WEB_BASE_URL: http://localhost:${AIDBOX_PORT:-8080}
+      BOX_WEB_BASE_URL: ${AIDBOX_BASE_URL:-http://localhost:${AIDBOX_PORT:-8080}}
       BOX_WEB_PORT: 8080
       BOX_INIT_BUNDLE: file:///tmp/bundle.json
+      BOX_LICENSE: ${BOX_LICENSE:-}
     healthcheck:
       test: curl -f http://localhost:8080/health || exit 1
       interval: 5s

--- a/packages/aidbox-client/docker-compose.yaml
+++ b/packages/aidbox-client/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     depends_on:
     - postgres
     ports:
-    - 8080:8080
+    - "${AIDBOX_PORT:-8080}:8080"
     volumes:
       - "./resources/bundle.json:/tmp/bundle.json:z"
     environment:
@@ -47,7 +47,7 @@ services:
       BOX_SECURITY_AUDIT_LOG_ENABLED: 'true'
       BOX_SECURITY_DEV_MODE: 'true'
       BOX_SETTINGS_MODE: read-write
-      BOX_WEB_BASE_URL: http://localhost:8080
+      BOX_WEB_BASE_URL: http://localhost:${AIDBOX_PORT:-8080}
       BOX_WEB_PORT: 8080
       BOX_INIT_BUNDLE: file:///tmp/bundle.json
     healthcheck:

--- a/packages/aidbox-client/test/basic-auth.test.ts
+++ b/packages/aidbox-client/test/basic-auth.test.ts
@@ -3,8 +3,7 @@ import { AidboxClient } from "src/client.js";
 import type { Bundle, OperationOutcome } from "src/fhir-types/hl7-fhir-r4-core";
 import type { User } from "src/types";
 import { describe, expect, it } from "vitest";
-
-const baseUrl = "http://localhost:8080";
+import { baseUrl } from "./config";
 
 describe("BasicAuthProvider", () => {
 	describe("restricted access policy", () => {

--- a/packages/aidbox-client/test/config.ts
+++ b/packages/aidbox-client/test/config.ts
@@ -1,0 +1,11 @@
+// `types: []` keeps Node globals out of these sources, so `process` is read off `globalThis` rather than imported.
+const env = (
+	globalThis as typeof globalThis & {
+		process?: { env?: Record<string, string | undefined> };
+	}
+).process?.env;
+
+const port = env?.AIDBOX_PORT ?? "8080";
+
+/** Address of the Aidbox instance the integration tests run against. */
+export const baseUrl = env?.AIDBOX_BASE_URL ?? `http://localhost:${port}`;

--- a/packages/aidbox-client/test/config.ts
+++ b/packages/aidbox-client/test/config.ts
@@ -1,11 +1,9 @@
-// `types: []` keeps Node globals out of these sources, so `process` is read off `globalThis` rather than imported.
 const env = (
 	globalThis as typeof globalThis & {
 		process?: { env?: Record<string, string | undefined> };
 	}
 ).process?.env;
 
-const port = env?.AIDBOX_PORT ?? "8080";
+const port = env?.AIDBOX_PORT || "8080";
 
-/** Address of the Aidbox instance the integration tests run against. */
-export const baseUrl = env?.AIDBOX_BASE_URL ?? `http://localhost:${port}`;
+export const baseUrl = env?.AIDBOX_BASE_URL || `http://localhost:${port}`;

--- a/packages/aidbox-client/test/fhir-http.test.ts
+++ b/packages/aidbox-client/test/fhir-http.test.ts
@@ -7,8 +7,7 @@ import type {
 } from "src/fhir-types/hl7-fhir-r4-core";
 import type { User } from "src/types";
 import { beforeAll, describe, expect, it } from "vitest";
-
-const baseUrl = "http://localhost:8080";
+import { baseUrl } from "./config";
 
 const authProvider = new BasicAuthProvider(baseUrl, "basic", "Pa$$w0rd");
 

--- a/packages/aidbox-client/test/global-setup.ts
+++ b/packages/aidbox-client/test/global-setup.ts
@@ -1,0 +1,101 @@
+/// <reference types="node" />
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const packageDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const COMPOSE_PROJECT = "aidbox-client-tests";
+
+const FIXTURE_MARKER = "/AccessPolicy/basic-restricted-policy";
+
+function compose(...args: string[]) {
+	return execFileAsync("docker", ["compose", "-p", COMPOSE_PROJECT, ...args], {
+		cwd: packageDir,
+		maxBuffer: 64 * 1024 * 1024,
+	});
+}
+
+function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.on("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (address === null || typeof address === "string") {
+				server.close();
+				reject(new Error("could not determine a free port"));
+				return;
+			}
+			server.close(() => resolve(address.port));
+		});
+	});
+}
+
+async function fixtureCredentials(): Promise<string> {
+	const bundle = JSON.parse(
+		await readFile(join(packageDir, "resources/bundle.json"), "utf8"),
+	) as { entry: { request: { url: string }; resource: { secret?: string } }[] };
+	const client = bundle.entry.find((e) => e.request.url === "/Client/basic");
+	if (!client?.resource.secret) {
+		throw new Error("resources/bundle.json no longer seeds Client/basic");
+	}
+	return `Basic ${btoa(`basic:${client.resource.secret}`)}`;
+}
+
+async function fetchMarker(baseUrl: string): Promise<Response> {
+	try {
+		return await fetch(`${baseUrl}${FIXTURE_MARKER}`, {
+			headers: { authorization: await fixtureCredentials() },
+			signal: AbortSignal.timeout(10_000),
+		});
+	} catch (cause) {
+		throw new Error(`No Aidbox answering at ${baseUrl}`, { cause });
+	}
+}
+
+export default async function setup() {
+	const supplied = process.env.AIDBOX_BASE_URL;
+	if (supplied) {
+		const response = await fetchMarker(supplied);
+		if (!response.ok) {
+			throw new Error(
+				`The Aidbox at ${supplied} was not seeded by packages/aidbox-client/resources/bundle.json ` +
+					`(${FIXTURE_MARKER} returned ${response.status}). These tests truncate tables, so they refuse ` +
+					`to touch an instance they do not recognise. Unset AIDBOX_BASE_URL to let them start their own.`,
+			);
+		}
+		return;
+	}
+
+	const port = process.env.AIDBOX_PORT || String(await freePort());
+	process.env.AIDBOX_PORT = port;
+	const baseUrl = `http://localhost:${port}`;
+	const teardown = async () => {
+		await compose("down", "--volumes");
+	};
+
+	try {
+		await compose("up", "--wait");
+		const response = await fetchMarker(baseUrl);
+		if (!response.ok) {
+			throw new Error(
+				`The instance at ${baseUrl} did not load resources/bundle.json (${FIXTURE_MARKER} returned ` +
+					`${response.status}). An Aidbox without a licence reports itself healthy while serving nothing ` +
+					`but its activation screen, so check BOX_LICENSE.`,
+			);
+		}
+	} catch (error) {
+		await teardown();
+		throw error;
+	}
+
+	process.env.AIDBOX_BASE_URL = baseUrl;
+	return teardown;
+}

--- a/packages/aidbox-client/test/smart-app-launch.test.ts
+++ b/packages/aidbox-client/test/smart-app-launch.test.ts
@@ -10,8 +10,7 @@ import {
 	type SmartSession,
 } from "src/smart-app-launch";
 import { afterEach, describe, expect, it, vi } from "vitest";
-
-const AIDBOX_BASE_URL = "http://localhost:8080";
+import { baseUrl as AIDBOX_BASE_URL } from "./config";
 
 const ISS = "https://fhir.example.com";
 const AUTHORIZE_URL = "https://auth.example.com/authorize";

--- a/packages/aidbox-client/test/smart-backend-services.test.ts
+++ b/packages/aidbox-client/test/smart-backend-services.test.ts
@@ -8,8 +8,8 @@ import type {
 import { SmartBackendServicesAuthProvider } from "src/smart-backend-services";
 import type { User } from "src/types";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { baseUrl as AIDBOX_BASE_URL } from "./config";
 
-const AIDBOX_BASE_URL = "http://localhost:8080";
 const SMART_CLIENT_ID = "smart-backend-test";
 
 /**

--- a/packages/aidbox-client/vitest.config.ts
+++ b/packages/aidbox-client/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
 		// Note: sequence.concurrent only affects tests within a file, not between files.
 		// Note: pool: 'forks' with singleFork breaks native fetch in CI (returns undefined).
 		fileParallelism: false,
+		globalSetup: ["./test/global-setup.ts"],
+		teardownTimeout: 60_000,
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
## What

The integration tests now read the server address from `test/config.ts` instead of
repeating a literal in every file. `AIDBOX_PORT` sets the host port for both the
tests and `docker-compose.yaml`. `AIDBOX_BASE_URL` replaces the whole address, for
an instance that is not on localhost. Both are described in `CONTRIBUTING.md`.

`client.test.ts` and `utils.test.ts` still use literals. The URL there is test data,
not a server anyone connects to.

## Why

Four test files hardcoded `http://localhost:8080`. If another container or service
already held that port, there was no way to run the integration suite without
editing the tests first.

`BOX_WEB_BASE_URL` has to move with the port. Aidbox builds the endpoints it
advertises in `.well-known/smart-configuration` from that setting, so SMART
discovery pointed at 8080 while the instance was listening on another port.

## How to test

```bash
cd packages/aidbox-client
AIDBOX_PORT=18080 docker compose up --wait
AIDBOX_PORT=18080 pnpm test


## Affected packages

- [x] `@health-samurai/aidbox-client`
- [ ] `@health-samurai/react-components`
- [ ] `@health-samurai/aidbox-fhirpath-lsp`
- [ ] `@health-samurai/create-react-app`
