### PR TITLE
Run e2e on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/aidbox-client.yaml
+++ b/.github/workflows/aidbox-client.yaml
@@ -2,18 +2,26 @@ name: Test Aidbox Client
 
 on:
   push:
-    branches: [master]
-  pull_request_target:
+    branches: [master, development]
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   e2e:
+    # Secrets are not exposed to fork pull requests and Aidbox needs BOX_LICENSE to boot.
+    # Fork changes get covered by the push run after they land.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -27,17 +35,20 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: packages/aidbox-client
 
+      # The value reaches docker compose through the environment, so it never lands on disk.
       - name: Activate Aidbox
         run: |
-          cat > docker-compose.override.yml << EOF
+          cat > docker-compose.override.yml <<'EOF'
           services:
             aidbox:
               environment:
-                BOX_LICENSE: ${{ secrets.BOX_LICENSE }}
+                BOX_LICENSE: ${BOX_LICENSE}
           EOF
         working-directory: packages/aidbox-client
 
       - name: Run aidbox
+        env:
+          BOX_LICENSE: ${{ secrets.BOX_LICENSE }}
         run: docker compose up --wait
         working-directory: packages/aidbox-client
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,20 @@ pnpm -r run build   # initial build (required for cross-package types)
 
 6. **Open a pull request** against `development`.
 
+## Integration tests
+
+The `aidbox-client` suite talks to a real Aidbox started from
+`packages/aidbox-client/docker-compose.yaml`. That container serves no API until
+it is activated, so a `BOX_LICENSE` is required. Without one it still boots and
+reports itself healthy, but redirects every request to its activation screen.
+Ask a maintainer if you need a license for local work.
+
+On CI the `Test Aidbox Client` workflow runs only for branches in this
+repository. GitHub does not expose secrets to pull requests opened from a fork,
+so `BOX_LICENSE` is unavailable there and the job is skipped. Changes from a
+fork get their integration run once they land on `development`, and a maintainer
+can push the branch here to see the suite before merging.
+
 ## Code style
 
 All formatting and linting is handled by [Biome](https://biomejs.dev/).


### PR DESCRIPTION
## What

The `Test Aidbox Client` workflow moves from `pull_request_target` to
`pull_request`. The `e2e` job runs for pushes to `master` and `development` and
for pull requests from branches in this repository, and is skipped for pull
requests opened from a fork. `BOX_LICENSE` now reaches `docker compose` through
the environment instead of being written into `docker-compose.override.yml`, and
the checkout no longer leaves credentials in the working copy.

`CONTRIBUTING.md` gains a section on what the integration suite needs and why the
job does not run on fork pull requests.

## Why

`actions/checkout` refuses to fetch fork code inside a `pull_request_target`
workflow, so `e2e` has been failing at the checkout step on every pull request
from a fork. The action offers `allow-unsafe-pr-checkout: true` as an opt-in, but
that runs a contributor's code with the base repository's `GITHUB_TOKEN` and
secrets, so it is not a way out.

Under `pull_request` secrets are not exposed to forks at all, and Aidbox serves
no API without `BOX_LICENSE`, so the job cannot do anything useful there. Those
changes get their integration run once they land on `development`, and a
maintainer can push the branch here to see the suite before merging.

## How to test

Push a branch to this repository and open a pull request from it. `e2e` runs as
before. From a fork it is skipped instead of failing at checkout.

`e2e` on this pull request will still fail: `pull_request_target` takes the
workflow from the base branch, so the current one keeps running until this lands
on `development`.

## Affected packages

- [x] `@health-samurai/aidbox-client`
- [ ] `@health-samurai/react-components`
- [ ] `@health-samurai/aidbox-fhirpath-lsp`
- [ ] `@health-samurai/create-react-app`
