### PR TITLE
Handle empty response bodies outside delete()

### DIFF
--- a/packages/aidbox-client/src/client.ts
+++ b/packages/aidbox-client/src/client.ts
@@ -173,6 +173,42 @@ export class AidboxClient<
 		}
 	}
 
+	async #toResult<T>(
+		response: ResponseWithMeta,
+	): Promise<
+		Result<ResourceResponse<T | undefined>, ResourceResponse<TOperationOutcome>>
+	> {
+		// Aidbox labels its 204 responses `content-type: text/html`, so the status is the only dependable signal that there is no body.
+		if (response.response.status === 204)
+			return Ok({ resource: undefined, ...response });
+
+		const body = await coerceBody<T | TOperationOutcome>(response);
+
+		if (!response.response.ok) {
+			if ((body as OperationOutcome).resourceType === "OperationOutcome")
+				return Err({ resource: body as TOperationOutcome, ...response });
+
+			throw new ErrorResponse(
+				`HTTP ${response.response.status}: ${response.response.statusText}`,
+				response,
+			);
+		}
+
+		return Ok({ resource: body as T, ...response });
+	}
+
+	async #requestMaybeEmpty<T>(
+		params: RequestParams,
+	): Promise<
+		Result<ResourceResponse<T | undefined>, ResourceResponse<TOperationOutcome>>
+	> {
+		const response = await this.#internalRawRequest(params);
+
+		if (isInternalErrorResponse(response)) throw response.error;
+
+		return await this.#toResult<T>(response);
+	}
+
 	/// FHIR HTTP methods
 
 	/**
@@ -581,29 +617,10 @@ export class AidboxClient<
 	): Promise<
 		Result<ResourceResponse<T | undefined>, ResourceResponse<TOperationOutcome>>
 	> {
-		const response = await this.#internalRawRequest({
+		return await this.#requestMaybeEmpty<T>({
 			url: makeUrl([basePath, opts.type, opts.id]),
 			method: "DELETE",
 		});
-
-		if (isInternalErrorResponse(response)) throw response.error;
-
-		if (response.response.status === 204)
-			return Ok({ resource: undefined, ...response });
-
-		const body = await coerceBody<T | TOperationOutcome>(response);
-
-		if (!response.response.ok) {
-			if ((body as OperationOutcome).resourceType === "OperationOutcome")
-				return Err({ resource: body as TOperationOutcome, ...response });
-
-			throw new ErrorResponse(
-				`HTTP ${response.response.status}: ${response.response.statusText}`,
-				response,
-			);
-		}
-
-		return Ok({ resource: body as T, ...response });
 	}
 
 	/**
@@ -669,7 +686,9 @@ export class AidboxClient<
 	 */
 	public async conditionalDelete<T>(
 		opts: ConditionalDeleteOptions,
-	): Promise<Result<ResourceResponse<T>, ResourceResponse<TOperationOutcome>>> {
+	): Promise<
+		Result<ResourceResponse<T | undefined>, ResourceResponse<TOperationOutcome>>
+	> {
 		const url = [basePath];
 		if (opts.type) url.push(opts.type);
 
@@ -679,7 +698,7 @@ export class AidboxClient<
 			params: opts.searchParameters,
 		};
 
-		return await this.request<T>(requestParams);
+		return await this.#requestMaybeEmpty<T>(requestParams);
 	}
 
 	/**
@@ -1069,19 +1088,18 @@ export class AidboxClient<
 
 		if (isInternalErrorResponse(response)) throw response.error;
 
-		const body = await coerceBody<T | TOperationOutcome>(response);
+		const result = await this.#toResult<T>(response);
 
-		if (!response.response.ok) {
-			if ((body as OperationOutcome).resourceType === "OperationOutcome")
-				return Err({ resource: body as TOperationOutcome, ...response });
-
+		if (result.isOk() && result.value.resource === undefined)
 			throw new ErrorResponse(
-				`HTTP ${response.response.status}: ${response.response.statusText}`,
+				`HTTP ${response.response.status}: response carries no body, use rawRequest for this interaction`,
 				response,
 			);
-		}
 
-		return Ok({ resource: body as T, ...response });
+		return result as Result<
+			ResourceResponse<T>,
+			ResourceResponse<TOperationOutcome>
+		>;
 	}
 
 	/**

--- a/packages/aidbox-client/src/utils.ts
+++ b/packages/aidbox-client/src/utils.ts
@@ -72,6 +72,7 @@ export const coerceBody = async <T>(meta: ResponseWithMeta): Promise<T> => {
 			case "application/fhir+json":
 				return await responseCopy.json();
 			case "text/yaml":
+			case "application/yaml":
 				return YAML.parse(await responseCopy.text());
 		}
 	} catch (e) {

--- a/packages/aidbox-client/test/response-parsing.test.ts
+++ b/packages/aidbox-client/test/response-parsing.test.ts
@@ -1,0 +1,103 @@
+import { AidboxClient } from "src/client";
+import type { AuthProvider } from "src/types";
+import { describe, expect, it } from "vitest";
+
+const baseUrl = "http://localhost:8080";
+
+const clientAnswering = (make: () => Response) =>
+	new AidboxClient(baseUrl, {
+		baseUrl,
+		fetch: async () => make(),
+		establishSession: () => {},
+		revokeSession: () => {},
+	} as AuthProvider);
+
+// Aidbox really does label its empty responses `text/html`.
+const noContent = () =>
+	new Response(null, {
+		status: 204,
+		statusText: "No Content",
+		headers: { "content-type": "text/html" },
+	});
+
+describe("empty response bodies", () => {
+	it("resolves delete of an already deleted resource to Ok(undefined)", async () => {
+		const result = await clientAnswering(noContent).delete({
+			type: "Patient",
+			id: "gone",
+		});
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) expect(result.value.resource).toBeUndefined();
+	});
+
+	it("resolves conditionalDelete without matches to Ok(undefined)", async () => {
+		const result = await clientAnswering(noContent).conditionalDelete({
+			type: "Patient",
+			searchParameters: [["family", "NoSuchFamily"]],
+		});
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) expect(result.value.resource).toBeUndefined();
+	});
+
+	it("treats an empty response without a content type the same way", async () => {
+		const result = await clientAnswering(
+			() => new Response(null, { status: 204 }),
+		).delete({ type: "Patient", id: "gone" });
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) expect(result.value.resource).toBeUndefined();
+	});
+});
+
+describe("bodies the server did not encode as FHIR", () => {
+	it("still surfaces a coercion failure for an unparseable success", async () => {
+		const request = clientAnswering(
+			() =>
+				new Response("not fhir", {
+					status: 200,
+					headers: { "content-type": "text/html" },
+				}),
+		).read({ type: "Patient", id: "p1" });
+
+		await expect(request).rejects.toThrow("unknown content-type");
+	});
+});
+
+describe("content types carrying FHIR payloads", () => {
+	const patient = { resourceType: "Patient", id: "p1" };
+
+	it.each([
+		"application/json",
+		"application/fhir+json",
+		"application/fhir+json;charset=utf-8",
+	])("parses %s", async (contentType) => {
+		const result = await clientAnswering(
+			() =>
+				new Response(JSON.stringify(patient), {
+					status: 200,
+					headers: { "content-type": contentType },
+				}),
+		).read<typeof patient>({ type: "Patient", id: "p1" });
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) expect(result.value.resource).toMatchObject(patient);
+	});
+
+	it.each([
+		"text/yaml",
+		"application/yaml",
+	])("parses %s", async (contentType) => {
+		const result = await clientAnswering(
+			() =>
+				new Response("resourceType: Patient\nid: p1\n", {
+					status: 200,
+					headers: { "content-type": contentType },
+				}),
+		).read<typeof patient>({ type: "Patient", id: "p1" });
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) expect(result.value.resource).toMatchObject(patient);
+	});
+});


### PR DESCRIPTION
## What

`conditionalDelete` and `delete` now share one response parsing path. The 204
branch that only `delete` had moved into `#toResult`, so both resolve an empty
response to `Ok` with `resource: undefined`. `coerceBody` also accepts
`application/yaml`.

Breaking: `conditionalDelete` returns `Result<ResourceResponse<T | undefined>, ...>`
instead of `Result<ResourceResponse<T>, ...>`, which is the shape `delete` has
always had. Callers that read `result.value.resource` directly need a guard or
`?.`. The code this breaks was already failing at runtime, since the call threw
whenever the search matched nothing.

`deleteHistory` and `deleteHistoryVersion` are left alone. Aidbox has no route for
either of them, so there is nothing to observe there.

## Why

A conditional delete that matches nothing gets `204 No Content` from Aidbox, and
`request` always coerces a body, so the call threw `failed to coerce body: unknown
content-type text/html` instead of returning `Ok`. Aidbox labels those responses
`content-type: text/html`, so the status code is what decides, not the header.

Aidbox also serves `application/yaml` when a request asks for it, while
`coerceBody` only knew `text/yaml`.

## How to test

Against a licensed Aidbox:

```bash
cd packages/aidbox-client
docker compose up --wait
pnpm test
```
test/response-parsing.test.ts stubs the transport and needs no server. Two of its
nine cases fail on development and pass here: the conditional delete with no
matches, and application/yaml.


## Affected packages

- [x] `@health-samurai/aidbox-client`
- [ ] `@health-samurai/react-components`
- [ ] `@health-samurai/aidbox-fhirpath-lsp`
- [ ] `@health-samurai/create-react-app`
